### PR TITLE
fix: address PR #13 review feedback

### DIFF
--- a/src/exploratory-testing/db/workspace-repository.ts
+++ b/src/exploratory-testing/db/workspace-repository.ts
@@ -2,9 +2,14 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
 import { Database } from "bun:sqlite";
+import { z } from "zod";
 
 import { WORKFLOW_SKILLS, getWorkflowSkillOrThrow } from "../config/workflow";
-import type { PrMetadata } from "../models/pr-intake";
+import {
+  type PrMetadata,
+  changedFileSchema,
+  reviewCommentSchema,
+} from "../models/pr-intake";
 import {
   type ProgressStatus,
   type StepProgressSnapshot,
@@ -391,59 +396,63 @@ export function savePrIntake(
   const timestamp = new Date().toISOString();
 
   try {
-    database
-      .query(
-        `
-        INSERT INTO pr_intakes (
-          provider, repository, pr_number, title, description,
-          author, base_branch, head_branch, head_sha,
-          linked_issues_json, changed_files_json, review_comments_json,
-          fetched_at, created_at, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
-        ON CONFLICT(provider, repository, pr_number, head_sha) DO UPDATE SET
-          title = excluded.title,
-          description = excluded.description,
-          author = excluded.author,
-          base_branch = excluded.base_branch,
-          head_branch = excluded.head_branch,
-          linked_issues_json = excluded.linked_issues_json,
-          changed_files_json = excluded.changed_files_json,
-          review_comments_json = excluded.review_comments_json,
-          fetched_at = excluded.fetched_at,
-          updated_at = excluded.updated_at
-        `,
-      )
-      .run(
-        metadata.provider,
-        metadata.repository,
-        metadata.prNumber,
-        metadata.title,
-        metadata.description,
-        metadata.author,
-        metadata.baseBranch,
-        metadata.headBranch,
-        metadata.headSha,
-        JSON.stringify(metadata.linkedIssues),
-        JSON.stringify(metadata.changedFiles),
-        JSON.stringify(metadata.reviewComments),
-        metadata.fetchedAt,
-        timestamp,
-        timestamp,
-      );
+    const persist = database.transaction(() => {
+      database
+        .query(
+          `
+          INSERT INTO pr_intakes (
+            provider, repository, pr_number, title, description,
+            author, base_branch, head_branch, head_sha,
+            linked_issues_json, changed_files_json, review_comments_json,
+            fetched_at, created_at, updated_at
+          ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+          ON CONFLICT(provider, repository, pr_number, head_sha) DO UPDATE SET
+            title = excluded.title,
+            description = excluded.description,
+            author = excluded.author,
+            base_branch = excluded.base_branch,
+            head_branch = excluded.head_branch,
+            linked_issues_json = excluded.linked_issues_json,
+            changed_files_json = excluded.changed_files_json,
+            review_comments_json = excluded.review_comments_json,
+            fetched_at = excluded.fetched_at,
+            updated_at = excluded.updated_at
+          `,
+        )
+        .run(
+          metadata.provider,
+          metadata.repository,
+          metadata.prNumber,
+          metadata.title,
+          metadata.description,
+          metadata.author,
+          metadata.baseBranch,
+          metadata.headBranch,
+          metadata.headSha,
+          JSON.stringify(metadata.linkedIssues),
+          JSON.stringify(metadata.changedFiles),
+          JSON.stringify(metadata.reviewComments),
+          metadata.fetchedAt,
+          timestamp,
+          timestamp,
+        );
 
-    const row = database
-      .query(
-        `
-        SELECT * FROM pr_intakes
-        WHERE provider = ?1 AND repository = ?2 AND pr_number = ?3 AND head_sha = ?4
-        `,
-      )
-      .get<PrIntakeRow>(
-        metadata.provider,
-        metadata.repository,
-        metadata.prNumber,
-        metadata.headSha,
-      );
+      return database
+        .query(
+          `
+          SELECT * FROM pr_intakes
+          WHERE provider = ?1 AND repository = ?2 AND pr_number = ?3 AND head_sha = ?4
+          `,
+        )
+        .get<PrIntakeRow>(
+          metadata.provider,
+          metadata.repository,
+          metadata.prNumber,
+          metadata.headSha,
+        );
+    });
+
+    const row = persist();
 
     if (!row) {
       throw new Error(
@@ -511,13 +520,13 @@ function mapPrIntakeRow(row: PrIntakeRow): PersistedPrIntake {
     baseBranch: row.base_branch,
     headBranch: row.head_branch,
     headSha: row.head_sha,
-    linkedIssues: JSON.parse(row.linked_issues_json) as string[],
-    changedFiles: JSON.parse(
-      row.changed_files_json,
-    ) as PrMetadata["changedFiles"],
-    reviewComments: JSON.parse(
-      row.review_comments_json,
-    ) as PrMetadata["reviewComments"],
+    linkedIssues: z.array(z.string()).parse(JSON.parse(row.linked_issues_json)),
+    changedFiles: z
+      .array(changedFileSchema)
+      .parse(JSON.parse(row.changed_files_json)),
+    reviewComments: z
+      .array(reviewCommentSchema)
+      .parse(JSON.parse(row.review_comments_json)),
     fetchedAt: row.fetched_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/exploratory-testing/scm/fetch-github.ts
+++ b/src/exploratory-testing/scm/fetch-github.ts
@@ -3,11 +3,10 @@ import { execa } from "execa";
 import type { PrMetadata } from "../models/pr-intake";
 import {
   buildPrMetadata,
-  ghPrFilesResponseSchema,
-  ghPrViewSchema,
   ghRepoViewSchema,
-  ghReviewsResponseSchema,
+  parseGhPrCommentsJson,
   parseGhPrFilesJson,
+  parseGhPrJson,
 } from "./github";
 
 export type FetchGithubPrInput = {
@@ -21,69 +20,31 @@ export async function fetchGithubPr(
   const cwd = input.repositoryRoot;
   const prNumber = String(input.prNumber);
 
-  const [prResult, filesResult, commentsResult, repoResult] = await Promise.all(
-    [
-      execa(
-        "gh",
-        [
-          "pr",
-          "view",
-          prNumber,
-          "--json",
-          "number,title,body,author,baseRefName,headRefName,headRefOid,closingIssuesReferences",
-        ],
-        { cwd },
-      ),
-      execa("gh", ["pr", "view", prNumber, "--json", "files"], { cwd }),
-      execa("gh", ["pr", "view", prNumber, "--json", "reviews"], { cwd }),
-      execa("gh", ["repo", "view", "--json", "nameWithOwner"], { cwd }),
-    ],
-  );
+  const [prResult, repoResult] = await Promise.all([
+    execa(
+      "gh",
+      [
+        "pr",
+        "view",
+        prNumber,
+        "--json",
+        "number,title,body,author,baseRefName,headRefName,headRefOid,closingIssuesReferences,files,reviews",
+      ],
+      { cwd },
+    ),
+    execa("gh", ["repo", "view", "--json", "nameWithOwner"], { cwd }),
+  ]);
 
-  const prJson = ghPrViewSchema.parse(JSON.parse(prResult.stdout));
-  const filesJson = ghPrFilesResponseSchema.parse(
-    JSON.parse(filesResult.stdout),
-  );
-  const reviewsJson = ghReviewsResponseSchema.parse(
-    JSON.parse(commentsResult.stdout),
-  );
+  const prJson = JSON.parse(prResult.stdout) as Record<string, unknown>;
   const repoJson = ghRepoViewSchema.parse(JSON.parse(repoResult.stdout));
 
-  const prData = {
-    prNumber: prJson.number,
-    title: prJson.title,
-    description: prJson.body ?? "",
-    author: prJson.author.login,
-    baseBranch: prJson.baseRefName,
-    headBranch: prJson.headRefName,
-    headSha: prJson.headRefOid,
-    linkedIssues: prJson.closingIssuesReferences.nodes.map(
-      (node) => `#${node.number}`,
-    ),
-  };
-
+  const prData = parseGhPrJson(prJson);
   const files = parseGhPrFilesJson(
-    filesJson.files as Record<string, unknown>[],
+    (prJson.files ?? []) as Record<string, unknown>[],
+  );
+  const comments = parseGhPrCommentsJson(
+    (prJson.reviews ?? []) as Record<string, unknown>[],
   );
 
-  const comments = extractReviewComments(reviewsJson.reviews);
-
   return buildPrMetadata(repoJson.nameWithOwner, prData, files, comments);
-}
-
-function extractReviewComments(
-  reviews: readonly {
-    author: { login: string };
-    body: string;
-    submittedAt?: string;
-  }[],
-): PrMetadata["reviewComments"] {
-  return reviews
-    .filter((review) => review.body.trim().length > 0)
-    .map((review) => ({
-      author: review.author.login,
-      body: review.body,
-      path: null,
-      createdAt: review.submittedAt ?? new Date().toISOString(),
-    }));
 }

--- a/src/exploratory-testing/scm/github.ts
+++ b/src/exploratory-testing/scm/github.ts
@@ -103,15 +103,17 @@ export function parseGhPrFilesJson(
 export function parseGhPrCommentsJson(
   json: readonly Record<string, unknown>[],
 ): readonly ReviewComment[] {
-  return json.map((comment) => {
-    const parsed = ghReviewSchema.parse(comment);
-    return {
-      author: parsed.author.login,
-      body: parsed.body,
-      path: null,
-      createdAt: parsed.submittedAt ?? new Date().toISOString(),
-    };
-  });
+  return json
+    .map((comment) => {
+      const parsed = ghReviewSchema.parse(comment);
+      return {
+        author: parsed.author.login,
+        body: parsed.body,
+        path: null,
+        createdAt: parsed.submittedAt ?? new Date().toISOString(),
+      };
+    })
+    .filter((comment) => comment.body.trim().length > 0);
 }
 
 export function buildPrMetadata(

--- a/tests/unit/scm-github.test.ts
+++ b/tests/unit/scm-github.test.ts
@@ -140,6 +140,31 @@ describe("parseGhPrCommentsJson", () => {
       createdAt: "2026-04-01T00:00:00Z",
     });
   });
+
+  it("filters out empty review comments", () => {
+    const json = [
+      {
+        author: { login: "bob" },
+        body: "Looks good",
+        submittedAt: "2026-04-01T00:00:00Z",
+      },
+      {
+        author: { login: "carol" },
+        body: "",
+        submittedAt: "2026-04-01T01:00:00Z",
+      },
+      {
+        author: { login: "dave" },
+        body: "   ",
+        submittedAt: "2026-04-01T02:00:00Z",
+      },
+    ];
+
+    const result = parseGhPrCommentsJson(json);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.author).toBe("bob");
+  });
 });
 
 describe("buildPrMetadata", () => {


### PR DESCRIPTION
## Summary

Addresses review comments from Gemini Code Assist on #13.

- Combine 3 `gh pr view` calls into 1 single call with all fields (perf)
- Centralize empty review comment filtering in `parseGhPrCommentsJson` (DRY)
- Remove duplicated `extractReviewComments` from `fetch-github.ts`
- Wrap `savePrIntake` INSERT+SELECT in `transaction()` for atomicity
- Replace `JSON.parse` + `as` casts with Zod validation in `mapPrIntakeRow`

## Test plan

- [x] `bun run check` passes (lint + typecheck + 38 tests)
- [x] New test: empty review comments are filtered out
- [x] Existing tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)