### PR TITLE
feat: add allocation core and GitHub handoff workflow

### DIFF
--- a/src/exploratory-testing/cli/index.ts
+++ b/src/exploratory-testing/cli/index.ts
@@ -11,12 +11,26 @@ import {
 } from "../models/finding";
 import { progressStatusSchema } from "../models/progress";
 import { observationOutcomeSchema } from "../models/session";
+import {
+  listAllocation,
+  runAllocate,
+  summarizeAllocation,
+} from "../tools/allocate";
 import { runAssessGaps } from "../tools/assess-gaps";
 import { readPluginConfig } from "../tools/config";
 import { runDiscoverContext } from "../tools/discover-context";
 import { createEnvironmentReport } from "../tools/doctor";
 import { exportArtifacts } from "../tools/export-artifacts";
 import { runGenerateCharters } from "../tools/generate-charters";
+import {
+  generateHandoffMarkdown,
+  runAddHandoffComment,
+  runAddHandoffCommentRaw,
+  runCreateHandoffIssue,
+  runCreateHandoffIssueRaw,
+  runUpdateHandoffIssue,
+  runUpdateHandoffIssueBody,
+} from "../tools/handoff";
 import { readPluginManifest } from "../tools/manifest";
 import { runMapTests } from "../tools/map-tests";
 import { runPrIntake } from "../tools/pr-intake";
@@ -100,6 +114,57 @@ type HandoverCommandOptions = WorkspaceCommandOptions & {
   readonly nextStep?: string;
   readonly body?: string;
   readonly bodyFile?: string;
+};
+
+type AllocateCommandOptions = WorkspaceCommandOptions & {
+  readonly riskAssessmentId?: number;
+};
+
+type HandoffCreateCommandOptions = {
+  readonly repository?: string;
+  readonly title?: string;
+  readonly body?: string;
+  readonly bodyFile?: string;
+  readonly label?: string[];
+  readonly assignee?: string[];
+  readonly cwd?: string;
+};
+
+type HandoffGenerateCommandOptions = WorkspaceCommandOptions & {
+  readonly riskAssessmentId?: number;
+};
+
+type HandoffPublishCommandOptions = WorkspaceCommandOptions & {
+  readonly riskAssessmentId?: number;
+  readonly title?: string;
+  readonly label?: string[];
+  readonly assignee?: string[];
+};
+
+type HandoffAllocationUpdateCommandOptions = WorkspaceCommandOptions & {
+  readonly riskAssessmentId?: number;
+  readonly issueNumber?: number;
+};
+
+type HandoffFindingsCommandOptions = WorkspaceCommandOptions & {
+  readonly issueNumber?: number;
+  readonly sessionId?: number;
+};
+
+type HandoffUpdateCommandOptions = {
+  readonly repository?: string;
+  readonly issueNumber?: number;
+  readonly body?: string;
+  readonly bodyFile?: string;
+  readonly cwd?: string;
+};
+
+type HandoffCommentCommandOptions = {
+  readonly repository?: string;
+  readonly issueNumber?: number;
+  readonly body?: string;
+  readonly bodyFile?: string;
+  readonly cwd?: string;
 };
 
 export type JsonSuccessEnvelope<T> = {
@@ -382,6 +447,86 @@ cli
         handoverPath: result.handover.filePath,
         status: result.handover.snapshot.status,
       };
+    }),
+  );
+
+cli
+  .command("allocate run", "allocation core を実行して結果を永続化する")
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .action(
+    createEnvelopeAction(async (options: AllocateCommandOptions) => {
+      if (options.riskAssessmentId === undefined) {
+        throw new Error("--risk-assessment-id オプションは必須です。");
+      }
+
+      const result = await runAllocate({
+        riskAssessmentId: options.riskAssessmentId,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return {
+        riskAssessmentId: result.riskAssessmentId,
+        allocatedItems: result.items.length,
+        destinationCounts: result.destinationCounts,
+      };
+    }),
+  );
+
+cli
+  .command("allocate list", "allocation 結果を一覧表示する")
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .action(
+    createEnvelopeAction(async (options: AllocateCommandOptions) => {
+      if (options.riskAssessmentId === undefined) {
+        throw new Error("--risk-assessment-id オプションは必須です。");
+      }
+
+      const result = await listAllocation({
+        riskAssessmentId: options.riskAssessmentId,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return {
+        riskAssessmentId: result.riskAssessmentId,
+        items: result.items,
+        destinationCounts: result.destinationCounts,
+      };
+    }),
+  );
+
+cli
+  .command("allocate summary", "allocation の destination 別サマリーを返す")
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .action(
+    createEnvelopeAction(async (options: AllocateCommandOptions) => {
+      if (options.riskAssessmentId === undefined) {
+        throw new Error("--risk-assessment-id オプションは必須です。");
+      }
+
+      const result = await summarizeAllocation({
+        riskAssessmentId: options.riskAssessmentId,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return result;
     }),
   );
 
@@ -838,6 +983,255 @@ cli
     }),
   );
 
+// ---------------------------------------------------------------------------
+// handoff commands (GitHub Issue integration)
+// ---------------------------------------------------------------------------
+
+cli
+  .command("handoff create-issue", "QA handoff Issue を GitHub に作成する")
+  .option("--repository <repository>", "リポジトリ名 (owner/repo 形式)")
+  .option("--title <title>", "Issue タイトル")
+  .option("--body <body>", "Issue 本文の Markdown")
+  .option("--body-file <bodyFile>", "Issue 本文 Markdown ファイルのパス")
+  .option("--label <label>", "ラベル（複数指定可）")
+  .option("--assignee <assignee>", "アサイン先（複数指定可）")
+  .option("--cwd <cwd>", "作業ディレクトリ (デフォルト: cwd)")
+  .action(
+    createEnvelopeAction(async (options: HandoffCreateCommandOptions) => {
+      if (!options.repository) {
+        throw new Error("--repository オプションは必須です。");
+      }
+      if (!options.title) {
+        throw new Error("--title オプションは必須です。");
+      }
+
+      const body = await readBodyOption(options.body, options.bodyFile);
+      if (!body) {
+        throw new Error("--body か --body-file のどちらかは必須です。");
+      }
+
+      const labels = normalizeArrayOption(options.label);
+      const assignees = normalizeArrayOption(options.assignee);
+
+      const result = await runCreateHandoffIssueRaw({
+        repositoryRoot: options.cwd ?? process.cwd(),
+        repository: options.repository,
+        title: options.title,
+        body,
+        labels: labels.length > 0 ? labels : undefined,
+        assignees: assignees.length > 0 ? assignees : undefined,
+      });
+
+      return {
+        issueNumber: result.issue.number,
+        issueUrl: result.issue.url,
+        title: result.issue.title,
+      };
+    }),
+  );
+
+cli
+  .command("handoff update-issue", "既存の QA handoff Issue の本文を更新する")
+  .option("--repository <repository>", "リポジトリ名 (owner/repo 形式)")
+  .option("--issue-number <issueNumber>", "Issue 番号")
+  .option("--body <body>", "更新後の Issue 本文の Markdown")
+  .option(
+    "--body-file <bodyFile>",
+    "更新後の Issue 本文 Markdown ファイルのパス",
+  )
+  .option("--cwd <cwd>", "作業ディレクトリ (デフォルト: cwd)")
+  .action(
+    createEnvelopeAction(async (options: HandoffUpdateCommandOptions) => {
+      if (!options.repository) {
+        throw new Error("--repository オプションは必須です。");
+      }
+      const issueNumber = validatePositiveIssueNumber(options.issueNumber);
+
+      const body = await readBodyOption(options.body, options.bodyFile);
+      if (!body) {
+        throw new Error("--body か --body-file のどちらかは必須です。");
+      }
+
+      await runUpdateHandoffIssueBody({
+        repositoryRoot: options.cwd ?? process.cwd(),
+        repository: options.repository,
+        issueNumber,
+        body,
+      });
+
+      return {
+        issueNumber,
+        updated: true,
+      };
+    }),
+  );
+
+cli
+  .command("handoff add-comment", "QA handoff Issue にコメントを追加する")
+  .option("--repository <repository>", "リポジトリ名 (owner/repo 形式)")
+  .option("--issue-number <issueNumber>", "Issue 番号")
+  .option("--body <body>", "コメント本文の Markdown")
+  .option("--body-file <bodyFile>", "コメント本文 Markdown ファイルのパス")
+  .option("--cwd <cwd>", "作業ディレクトリ (デフォルト: cwd)")
+  .action(
+    createEnvelopeAction(async (options: HandoffCommentCommandOptions) => {
+      if (!options.repository) {
+        throw new Error("--repository オプションは必須です。");
+      }
+      const issueNumber = validatePositiveIssueNumber(options.issueNumber);
+
+      const body = await readBodyOption(options.body, options.bodyFile);
+      if (!body) {
+        throw new Error("--body か --body-file のどちらかは必須です。");
+      }
+
+      const result = await runAddHandoffCommentRaw({
+        repositoryRoot: options.cwd ?? process.cwd(),
+        repository: options.repository,
+        issueNumber,
+        body,
+      });
+
+      return {
+        issueNumber,
+        commentUrl: result.comment.url,
+      };
+    }),
+  );
+
+cli
+  .command(
+    "handoff generate",
+    "allocation 結果から QA handoff Markdown を生成する",
+  )
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .action(
+    createEnvelopeAction(async (options: HandoffGenerateCommandOptions) => {
+      if (options.riskAssessmentId === undefined) {
+        throw new Error("--risk-assessment-id オプションは必須です。");
+      }
+
+      const result = await generateHandoffMarkdown({
+        riskAssessmentId: options.riskAssessmentId,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return {
+        riskAssessmentId: result.riskAssessmentId,
+        repository: result.repository,
+        markdown: result.markdown,
+        summary: result.summary,
+      };
+    }),
+  );
+
+cli
+  .command("handoff publish", "allocation 結果から QA handoff Issue を作成する")
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .option("--title <title>", "Issue タイトル")
+  .option("--label <label>", "ラベル（複数指定可）")
+  .option("--assignee <assignee>", "アサイン先（複数指定可）")
+  .action(
+    createEnvelopeAction(async (options: HandoffPublishCommandOptions) => {
+      if (options.riskAssessmentId === undefined) {
+        throw new Error("--risk-assessment-id オプションは必須です。");
+      }
+
+      const labels = normalizeArrayOption(options.label);
+      const assignees = normalizeArrayOption(options.assignee);
+      const result = await runCreateHandoffIssue({
+        riskAssessmentId: options.riskAssessmentId,
+        title: options.title,
+        labels: labels.length > 0 ? labels : undefined,
+        assignees: assignees.length > 0 ? assignees : undefined,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return {
+        riskAssessmentId: result.markdown.riskAssessmentId,
+        issueNumber: result.issue.number,
+        issueUrl: result.issue.url,
+        title: result.issue.title,
+      };
+    }),
+  );
+
+cli
+  .command("handoff update", "allocation 結果から QA handoff Issue を更新する")
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option(
+    "--risk-assessment-id <riskAssessmentId>",
+    "risk assessment レコード ID",
+  )
+  .option("--issue-number <issueNumber>", "Issue 番号")
+  .action(
+    createEnvelopeAction(
+      async (options: HandoffAllocationUpdateCommandOptions) => {
+        if (options.riskAssessmentId === undefined) {
+          throw new Error("--risk-assessment-id オプションは必須です。");
+        }
+        const issueNumber = validatePositiveIssueNumber(options.issueNumber);
+
+        const result = await runUpdateHandoffIssue({
+          riskAssessmentId: options.riskAssessmentId,
+          issueNumber,
+          configPath: options.config,
+          manifestPath: options.manifest,
+        });
+
+        return {
+          riskAssessmentId: result.markdown.riskAssessmentId,
+          issueNumber: result.issueNumber,
+          updated: true,
+        };
+      },
+    ),
+  );
+
+cli
+  .command(
+    "handoff add-findings",
+    "session findings を QA handoff Issue に追記する",
+  )
+  .option("--config <configPath>", "config.json のパス")
+  .option("--manifest <manifestPath>", "plugin.json のパス")
+  .option("--issue-number <issueNumber>", "Issue 番号")
+  .option("--session-id <sessionId>", "Session ID")
+  .action(
+    createEnvelopeAction(async (options: HandoffFindingsCommandOptions) => {
+      const issueNumber = validatePositiveIssueNumber(options.issueNumber);
+
+      if (options.sessionId === undefined) {
+        throw new Error("--session-id オプションは必須です。");
+      }
+
+      const result = await runAddHandoffComment({
+        issueNumber,
+        sessionId: options.sessionId,
+        configPath: options.config,
+        manifestPath: options.manifest,
+      });
+
+      return {
+        issueNumber,
+        commentUrl: result.comment.url,
+      };
+    }),
+  );
+
 cli.help();
 export async function main(argv: string[] = process.argv): Promise<void> {
   try {
@@ -867,4 +1261,23 @@ async function readBodyOption(
   }
 
   return inlineBody ?? null;
+}
+
+function normalizeArrayOption(
+  value: string | string[] | undefined,
+): readonly string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [value];
+}
+
+function validatePositiveIssueNumber(value: number | undefined): number {
+  if (value === undefined || !Number.isInteger(value) || value <= 0) {
+    throw new Error("--issue-number は正の整数を指定してください。");
+  }
+  return value;
 }

--- a/src/exploratory-testing/db/schema.ts
+++ b/src/exploratory-testing/db/schema.ts
@@ -122,6 +122,40 @@ CREATE TABLE IF NOT EXISTS risk_assessments (
   updated_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS allocation_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  risk_assessment_id INTEGER NOT NULL
+    REFERENCES risk_assessments(id)
+    ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  changed_file_paths_json TEXT NOT NULL DEFAULT '[]',
+  risk_level TEXT NOT NULL
+    CHECK (risk_level IN ('high', 'medium', 'low')),
+  recommended_destination TEXT NOT NULL
+    CHECK (recommended_destination IN (
+      'review',
+      'unit',
+      'integration',
+      'e2e',
+      'visual',
+      'dev-box',
+      'manual-exploration',
+      'skip'
+    )),
+  confidence REAL NOT NULL
+    CHECK (confidence >= 0.0 AND confidence <= 1.0),
+  rationale TEXT NOT NULL,
+  source_signals_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_allocation_items_risk_assessment_id
+  ON allocation_items(risk_assessment_id);
+
+CREATE INDEX IF NOT EXISTS idx_allocation_items_destination
+  ON allocation_items(recommended_destination);
+
 CREATE TABLE IF NOT EXISTS session_charters (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   risk_assessment_id INTEGER NOT NULL UNIQUE

--- a/src/exploratory-testing/db/workspace-repository.ts
+++ b/src/exploratory-testing/db/workspace-repository.ts
@@ -6,6 +6,16 @@ import { Database } from "bun:sqlite";
 import { WORKFLOW_SKILLS, getWorkflowSkillOrThrow } from "../config/workflow";
 import { v } from "../lib/validation";
 import {
+  type AllocationDestination,
+  type AllocationDestinationCounts,
+  type AllocationItem,
+  type AllocationSourceSignals,
+  allocationDestinationSchema,
+  allocationItemSchema,
+  allocationSourceSignalsSchema,
+  createEmptyAllocationDestinationCounts,
+} from "../models/allocation";
+import {
   type ChangeAnalysisResult,
   fileChangeAnalysisSchema,
   relatedCodeCandidateSchema,
@@ -50,6 +60,7 @@ import {
 import {
   type TestMappingResult,
   coverageGapEntrySchema,
+  explorationPrioritySchema,
   testAssetSchema,
   testLayerSchema,
   testSummarySchema,
@@ -703,6 +714,23 @@ export function findChangeAnalysis(
   }
 }
 
+export function findChangeAnalysisById(
+  databasePath: string,
+  id: number,
+): PersistedChangeAnalysis | null {
+  const database = openDatabase(databasePath);
+
+  try {
+    const row = database
+      .query("SELECT * FROM change_analyses WHERE id = ?1")
+      .get<ChangeAnalysisRow>(id);
+
+    return row ? mapChangeAnalysisRow(row) : null;
+  } finally {
+    database.close();
+  }
+}
+
 function mapChangeAnalysisRow(row: ChangeAnalysisRow): PersistedChangeAnalysis {
   return {
     id: row.id,
@@ -833,6 +861,23 @@ export function findTestMapping(
         `,
       )
       .get<TestMappingRow>(changeAnalysisId);
+
+    return row ? mapTestMappingRow(row) : null;
+  } finally {
+    database.close();
+  }
+}
+
+export function findTestMappingById(
+  databasePath: string,
+  id: number,
+): PersistedTestMapping | null {
+  const database = openDatabase(databasePath);
+
+  try {
+    const row = database
+      .query("SELECT * FROM test_mappings WHERE id = ?1")
+      .get<TestMappingRow>(id);
 
     return row ? mapTestMappingRow(row) : null;
   } finally {
@@ -972,6 +1017,23 @@ export function findRiskAssessment(
   }
 }
 
+export function findRiskAssessmentById(
+  databasePath: string,
+  id: number,
+): PersistedRiskAssessment | null {
+  const database = openDatabase(databasePath);
+
+  try {
+    const row = database
+      .query("SELECT * FROM risk_assessments WHERE id = ?1")
+      .get<RiskAssessmentRow>(id);
+
+    return row ? mapRiskAssessmentRow(row) : null;
+  } finally {
+    database.close();
+  }
+}
+
 function mapRiskAssessmentRow(row: RiskAssessmentRow): PersistedRiskAssessment {
   return {
     id: row.id,
@@ -989,6 +1051,247 @@ function mapRiskAssessmentRow(row: RiskAssessmentRow): PersistedRiskAssessment {
       JSON.parse(row.exploration_themes_json),
     ),
     assessedAt: row.assessed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Allocation Items
+// ---------------------------------------------------------------------------
+
+export type PersistedAllocationItem = {
+  readonly id: number;
+  readonly riskAssessmentId: number;
+  readonly title: string;
+  readonly changedFilePaths: readonly string[];
+  readonly riskLevel: AllocationItem["riskLevel"];
+  readonly recommendedDestination: AllocationDestination;
+  readonly confidence: number;
+  readonly rationale: string;
+  readonly sourceSignals: AllocationSourceSignals;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+type AllocationItemRow = {
+  readonly id: number;
+  readonly risk_assessment_id: number;
+  readonly title: string;
+  readonly changed_file_paths_json: string;
+  readonly risk_level: string;
+  readonly recommended_destination: string;
+  readonly confidence: number;
+  readonly rationale: string;
+  readonly source_signals_json: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+type AllocationCountRow = {
+  readonly destination: string;
+  readonly count: number;
+};
+
+export function saveAllocationItems(
+  databasePath: string,
+  riskAssessmentId: number,
+  items: readonly AllocationItem[],
+): readonly PersistedAllocationItem[] {
+  const database = openDatabase(databasePath);
+  const timestamp = new Date().toISOString();
+
+  try {
+    const riskAssessment = requireRiskAssessment(
+      databasePath,
+      riskAssessmentId,
+    );
+
+    const normalizedItems = items.map((item) =>
+      allocationItemSchema.parse({
+        ...item,
+        riskAssessmentId,
+      }),
+    );
+
+    for (const item of normalizedItems) {
+      if (item.riskAssessmentId !== riskAssessmentId) {
+        throw new Error(
+          `Allocation item riskAssessmentId mismatch: expected ${riskAssessmentId}, got ${item.riskAssessmentId}`,
+        );
+      }
+    }
+
+    const persist = database.transaction(() => {
+      database
+        .query("DELETE FROM allocation_items WHERE risk_assessment_id = ?1")
+        .run(riskAssessmentId);
+
+      const insert = database.query(
+        `
+        INSERT INTO allocation_items (
+          risk_assessment_id,
+          title,
+          changed_file_paths_json,
+          risk_level,
+          recommended_destination,
+          confidence,
+          rationale,
+          source_signals_json,
+          created_at,
+          updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        `,
+      );
+
+      for (const item of normalizedItems) {
+        insert.run(
+          riskAssessment.id,
+          item.title,
+          JSON.stringify(item.changedFilePaths),
+          item.riskLevel,
+          item.recommendedDestination,
+          item.confidence,
+          item.rationale,
+          JSON.stringify(item.sourceSignals),
+          timestamp,
+          timestamp,
+        );
+      }
+
+      return database
+        .query(
+          `
+          SELECT * FROM allocation_items
+          WHERE risk_assessment_id = ?1
+          ORDER BY id
+          `,
+        )
+        .all<AllocationItemRow>(riskAssessmentId);
+    });
+
+    const rows = persist();
+    return rows.map(mapAllocationItemRow);
+  } finally {
+    database.close();
+  }
+}
+
+export function listAllocationItems(
+  databasePath: string,
+  riskAssessmentId: number,
+): readonly PersistedAllocationItem[] {
+  const database = openDatabase(databasePath);
+
+  try {
+    requireRiskAssessment(databasePath, riskAssessmentId);
+    const rows = database
+      .query(
+        `
+        SELECT * FROM allocation_items
+        WHERE risk_assessment_id = ?1
+        ORDER BY id
+        `,
+      )
+      .all<AllocationItemRow>(riskAssessmentId);
+
+    return rows.map(mapAllocationItemRow);
+  } finally {
+    database.close();
+  }
+}
+
+export function listAllocationItemsByDestination(
+  databasePath: string,
+  riskAssessmentId: number,
+  destination: AllocationDestination,
+): readonly PersistedAllocationItem[] {
+  const database = openDatabase(databasePath);
+
+  try {
+    requireRiskAssessment(databasePath, riskAssessmentId);
+    const rows = database
+      .query(
+        `
+        SELECT * FROM allocation_items
+        WHERE risk_assessment_id = ?1
+          AND recommended_destination = ?2
+        ORDER BY id
+        `,
+      )
+      .all<AllocationItemRow>(riskAssessmentId, destination);
+
+    return rows.map(mapAllocationItemRow);
+  } finally {
+    database.close();
+  }
+}
+
+export function countAllocationItemsByDestination(
+  databasePath: string,
+  riskAssessmentId: number,
+): AllocationDestinationCounts {
+  const database = openDatabase(databasePath);
+
+  try {
+    requireRiskAssessment(databasePath, riskAssessmentId);
+    const counts = createEmptyAllocationDestinationCounts();
+    const rows = database
+      .query(
+        `
+        SELECT recommended_destination AS destination, COUNT(*) AS count
+        FROM allocation_items
+        WHERE risk_assessment_id = ?1
+        GROUP BY recommended_destination
+        `,
+      )
+      .all<AllocationCountRow>(riskAssessmentId);
+
+    for (const row of rows) {
+      const destination = allocationDestinationSchema.parse(row.destination);
+      counts[destination] = row.count;
+    }
+
+    return counts;
+  } finally {
+    database.close();
+  }
+}
+
+function requireRiskAssessment(
+  databasePath: string,
+  riskAssessmentId: number,
+): PersistedRiskAssessment {
+  const riskAssessment = findRiskAssessmentById(databasePath, riskAssessmentId);
+
+  if (!riskAssessment) {
+    throw new Error(
+      `Risk assessment not found for id=${riskAssessmentId}. Run assess-gaps first.`,
+    );
+  }
+
+  return riskAssessment;
+}
+
+function mapAllocationItemRow(row: AllocationItemRow): PersistedAllocationItem {
+  return {
+    id: row.id,
+    riskAssessmentId: row.risk_assessment_id,
+    title: row.title,
+    changedFilePaths: v.parse(
+      v.array(v.string()),
+      JSON.parse(row.changed_file_paths_json),
+    ),
+    riskLevel: v.parse(explorationPrioritySchema, row.risk_level),
+    recommendedDestination: allocationDestinationSchema.parse(
+      row.recommended_destination,
+    ),
+    confidence: row.confidence,
+    rationale: row.rationale,
+    sourceSignals: v.parse(
+      allocationSourceSignalsSchema,
+      JSON.parse(row.source_signals_json),
+    ),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/src/exploratory-testing/models/allocation.ts
+++ b/src/exploratory-testing/models/allocation.ts
@@ -1,0 +1,69 @@
+import { nonEmptyString, positiveInteger, schema, v } from "../lib/validation";
+
+import { changeCategorySchema } from "./change-analysis";
+import { confidenceSchema } from "./change-analysis";
+import { coverageAspectSchema, testLayerSchema } from "./test-mapping";
+import { explorationPrioritySchema } from "./test-mapping";
+
+export const ALLOCATION_DESTINATIONS = [
+  "review",
+  "unit",
+  "integration",
+  "e2e",
+  "visual",
+  "dev-box",
+  "manual-exploration",
+  "skip",
+] as const;
+
+export const allocationDestinationSchema = schema(
+  v.picklist(ALLOCATION_DESTINATIONS),
+);
+
+export type AllocationDestination = v.InferOutput<
+  typeof allocationDestinationSchema
+>;
+
+export const allocationSourceSignalsSchema = schema(
+  v.object({
+    categories: v.array(changeCategorySchema),
+    existingTestLayers: v.array(testLayerSchema),
+    gapAspects: v.array(coverageAspectSchema),
+    reviewComments: v.array(v.string()),
+    riskSignals: v.array(v.string()),
+  }),
+);
+
+export type AllocationSourceSignals = v.InferOutput<
+  typeof allocationSourceSignalsSchema
+>;
+
+export const allocationItemSchema = schema(
+  v.object({
+    riskAssessmentId: positiveInteger(),
+    title: nonEmptyString(),
+    changedFilePaths: v.pipe(v.array(nonEmptyString()), v.minLength(1)),
+    riskLevel: explorationPrioritySchema,
+    recommendedDestination: allocationDestinationSchema,
+    confidence: confidenceSchema,
+    rationale: nonEmptyString(),
+    sourceSignals: allocationSourceSignalsSchema,
+  }),
+);
+
+export type AllocationItem = v.InferOutput<typeof allocationItemSchema>;
+
+export type AllocationDestinationCounts = Record<AllocationDestination, number>;
+
+export function createEmptyAllocationDestinationCounts(): AllocationDestinationCounts {
+  return {
+    review: 0,
+    unit: 0,
+    integration: 0,
+    e2e: 0,
+    visual: 0,
+    "dev-box": 0,
+    "manual-exploration": 0,
+    skip: 0,
+  };
+}

--- a/src/exploratory-testing/models/github-issue.ts
+++ b/src/exploratory-testing/models/github-issue.ts
@@ -1,0 +1,24 @@
+import { nonEmptyString, positiveInteger, schema, v } from "../lib/validation";
+
+// --- Valibot schemas for gh issue CLI JSON output ---
+
+/** gh issue create --json number,url,title の出力を検証 */
+export const createdIssueSchema = schema(
+  v.object({
+    number: positiveInteger(),
+    url: nonEmptyString(),
+    title: nonEmptyString(),
+  }),
+);
+
+/** gh issue comment の出力を検証 */
+export const createdCommentSchema = schema(
+  v.object({
+    url: nonEmptyString(),
+  }),
+);
+
+// --- Inferred types ---
+
+export type CreatedIssue = v.InferOutput<typeof createdIssueSchema>;
+export type CreatedComment = v.InferOutput<typeof createdCommentSchema>;

--- a/src/exploratory-testing/scm/github-issues.ts
+++ b/src/exploratory-testing/scm/github-issues.ts
@@ -1,0 +1,128 @@
+import { execa } from "execa";
+
+import { normalizeExecaError } from "../lib/execa-error";
+import {
+  type CreatedComment,
+  type CreatedIssue,
+  createdCommentSchema,
+  createdIssueSchema,
+} from "../models/github-issue";
+
+const EXTERNAL_COMMAND_TIMEOUT_MS = 30_000;
+
+// --- Input types ---
+
+export type CreateIssueInput = {
+  readonly repositoryRoot: string;
+  readonly repository: string;
+  readonly title: string;
+  readonly body: string;
+  readonly labels?: readonly string[];
+  readonly assignees?: readonly string[];
+};
+
+export type EditIssueInput = {
+  readonly repositoryRoot: string;
+  readonly repository: string;
+  readonly issueNumber: number;
+  readonly body: string;
+};
+
+export type AddCommentInput = {
+  readonly repositoryRoot: string;
+  readonly repository: string;
+  readonly issueNumber: number;
+  readonly body: string;
+};
+
+// --- Public functions ---
+
+export async function createIssue(
+  input: CreateIssueInput,
+): Promise<CreatedIssue> {
+  const args = [
+    "issue",
+    "create",
+    "--repo",
+    input.repository,
+    "--title",
+    input.title,
+    "--body",
+    input.body,
+    "--json",
+    "number,url,title",
+  ];
+
+  if (input.labels && input.labels.length > 0) {
+    for (const label of input.labels) {
+      args.push("--label", label);
+    }
+  }
+
+  if (input.assignees && input.assignees.length > 0) {
+    for (const assignee of input.assignees) {
+      args.push("--assignee", assignee);
+    }
+  }
+
+  const result = await runGhIssueCommand(args, input.repositoryRoot);
+  const json = JSON.parse(result.stdout) as unknown;
+  return createdIssueSchema.parse(json);
+}
+
+export async function editIssueBody(input: EditIssueInput): Promise<void> {
+  const args = [
+    "issue",
+    "edit",
+    String(input.issueNumber),
+    "--repo",
+    input.repository,
+    "--body",
+    input.body,
+  ];
+
+  await runGhIssueCommand(args, input.repositoryRoot);
+}
+
+export async function addIssueComment(
+  input: AddCommentInput,
+): Promise<CreatedComment> {
+  const args = [
+    "issue",
+    "comment",
+    String(input.issueNumber),
+    "--repo",
+    input.repository,
+    "--body",
+    input.body,
+  ];
+
+  // gh issue comment は JSON を返さず、プレーンテキスト URL を stdout に出力する
+  const result = await runGhIssueCommand(args, input.repositoryRoot);
+  const rawUrl = result.stdout.trim();
+  return createdCommentSchema.parse({ url: rawUrl });
+}
+
+// --- Private helpers ---
+
+async function runGhIssueCommand(
+  args: readonly string[],
+  cwd: string,
+): Promise<{ readonly stdout: string }> {
+  try {
+    return await execa("gh", [...args], {
+      cwd,
+      timeout: EXTERNAL_COMMAND_TIMEOUT_MS,
+      reject: true,
+      preferLocal: false,
+    });
+  } catch (error) {
+    throw new Error(
+      normalizeExecaError(
+        error,
+        { command: "gh", args, cwd, timeoutMs: EXTERNAL_COMMAND_TIMEOUT_MS },
+        "gh issue コマンドの実行に失敗しました",
+      ),
+    );
+  }
+}

--- a/src/exploratory-testing/tools/allocate.ts
+++ b/src/exploratory-testing/tools/allocate.ts
@@ -1,0 +1,585 @@
+import {
+  type PersistedAllocationItem,
+  countAllocationItemsByDestination,
+  findChangeAnalysisById,
+  findPrIntakeById,
+  findRiskAssessmentById,
+  findTestMappingById,
+  listAllocationItems,
+  saveAllocationItems,
+} from "../db/workspace-repository";
+import type { PersistedChangeAnalysis } from "../db/workspace-repository";
+import type { PersistedPrIntake } from "../db/workspace-repository";
+import type { PersistedRiskAssessment } from "../db/workspace-repository";
+import type { PersistedTestMapping } from "../db/workspace-repository";
+import {
+  ALLOCATION_DESTINATIONS,
+  type AllocationDestination,
+  type AllocationDestinationCounts,
+  type AllocationItem,
+  createEmptyAllocationDestinationCounts,
+} from "../models/allocation";
+import type { ChangeCategory } from "../models/change-analysis";
+import type { ResolvedPluginConfig } from "../models/config";
+import type {
+  CoverageAspect,
+  CoverageGapEntry,
+  ExplorationPriority,
+  TestLayer,
+} from "../models/test-mapping";
+import { readPluginConfig } from "./config";
+
+export type AllocateInput = {
+  readonly riskAssessmentId: number;
+  readonly configPath?: string;
+  readonly manifestPath?: string;
+};
+
+export type AllocationContext = {
+  readonly riskAssessment: PersistedRiskAssessment;
+  readonly testMapping: PersistedTestMapping;
+  readonly changeAnalysis: PersistedChangeAnalysis;
+  readonly prIntake: PersistedPrIntake;
+};
+
+export type AllocateResult = {
+  readonly riskAssessmentId: number;
+  readonly items: readonly PersistedAllocationItem[];
+  readonly destinationCounts: AllocationDestinationCounts;
+};
+
+export type ListAllocationResult = {
+  readonly riskAssessmentId: number;
+  readonly items: readonly PersistedAllocationItem[];
+  readonly destinationCounts: AllocationDestinationCounts;
+};
+
+export type AllocationRepresentativeItem = {
+  readonly destination: AllocationDestination;
+  readonly title: string;
+  readonly riskLevel: ExplorationPriority;
+  readonly confidence: number;
+};
+
+export type AllocationSummary = {
+  readonly riskAssessmentId: number;
+  readonly totalItems: number;
+  readonly destinationCounts: AllocationDestinationCounts;
+  readonly representativeItems: readonly AllocationRepresentativeItem[];
+};
+
+const DESTINATION_ORDER = new Map(
+  ALLOCATION_DESTINATIONS.map(
+    (destination, index) => [destination, index] as const,
+  ),
+);
+
+export async function runAllocate(
+  input: AllocateInput,
+): Promise<AllocateResult> {
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+  const context = resolveAllocationContext(config, input.riskAssessmentId);
+  const items = buildAllocationItems(context);
+  const persisted = saveAllocationItems(
+    config.paths.database,
+    input.riskAssessmentId,
+    items,
+  );
+
+  return {
+    riskAssessmentId: input.riskAssessmentId,
+    items: persisted,
+    destinationCounts: countAllocationItemsByDestination(
+      config.paths.database,
+      input.riskAssessmentId,
+    ),
+  };
+}
+
+export async function listAllocation(
+  input: AllocateInput,
+): Promise<ListAllocationResult> {
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+  const items = listAllocationItems(
+    config.paths.database,
+    input.riskAssessmentId,
+  );
+
+  return {
+    riskAssessmentId: input.riskAssessmentId,
+    items,
+    destinationCounts: countAllocationItemsByDestination(
+      config.paths.database,
+      input.riskAssessmentId,
+    ),
+  };
+}
+
+export async function summarizeAllocation(
+  input: AllocateInput,
+): Promise<AllocationSummary> {
+  const listResult = await listAllocation(input);
+  return summarizeAllocationItems(
+    listResult.items,
+    listResult.riskAssessmentId,
+  );
+}
+
+export function buildAllocationItems(
+  context: AllocationContext,
+): readonly AllocationItem[] {
+  const fileAnalysisByPath = new Map(
+    context.changeAnalysis.fileAnalyses.map(
+      (analysis) => [analysis.path, analysis] as const,
+    ),
+  );
+  const gapsByFile = groupCoverageGapsByFile(
+    context.testMapping.coverageGapMap,
+  );
+  const riskScoreByFile = new Map(
+    context.riskAssessment.riskScores.map(
+      (score) => [score.changedFilePath, score] as const,
+    ),
+  );
+
+  const items: AllocationItem[] = [];
+
+  for (const [filePath, fileAnalysis] of fileAnalysisByPath.entries()) {
+    const gaps = gapsByFile.get(filePath) ?? [];
+    const riskScore = riskScoreByFile.get(filePath) ?? null;
+    const existingTestLayers = deriveExistingTestLayers(
+      filePath,
+      context.testMapping,
+    );
+    const reviewComments = deriveReviewComments(filePath, context.prIntake);
+
+    for (const gap of gaps) {
+      items.push(
+        buildAllocationItem({
+          riskAssessmentId: context.riskAssessment.id,
+          fileAnalysis,
+          gap,
+          riskScore,
+          existingTestLayers,
+          reviewComments,
+        }),
+      );
+    }
+  }
+
+  items.sort((a, b) => {
+    const fileComparison = a.changedFilePaths[0].localeCompare(
+      b.changedFilePaths[0],
+    );
+    if (fileComparison !== 0) {
+      return fileComparison;
+    }
+
+    const destinationComparison =
+      (DESTINATION_ORDER.get(a.recommendedDestination) ?? 0) -
+      (DESTINATION_ORDER.get(b.recommendedDestination) ?? 0);
+
+    if (destinationComparison !== 0) {
+      return destinationComparison;
+    }
+
+    return a.title.localeCompare(b.title);
+  });
+
+  return items;
+}
+
+export function summarizeAllocationItems(
+  items: readonly PersistedAllocationItem[],
+  riskAssessmentId: number,
+): AllocationSummary {
+  const destinationCounts = countItemsByDestination(items);
+  const representativeItems: AllocationRepresentativeItem[] = [];
+
+  for (const destination of ALLOCATION_DESTINATIONS) {
+    const item = items.find(
+      (candidate) => candidate.recommendedDestination === destination,
+    );
+    if (!item) {
+      continue;
+    }
+
+    representativeItems.push({
+      destination,
+      title: item.title,
+      riskLevel: item.riskLevel,
+      confidence: item.confidence,
+    });
+  }
+
+  return {
+    riskAssessmentId,
+    totalItems: items.length,
+    destinationCounts,
+    representativeItems,
+  };
+}
+
+function resolveAllocationContext(
+  config: ResolvedPluginConfig,
+  riskAssessmentId: number,
+): AllocationContext {
+  const riskAssessment = findRiskAssessmentById(
+    config.paths.database,
+    riskAssessmentId,
+  );
+
+  if (!riskAssessment) {
+    throw new Error(
+      `Risk assessment not found for id=${riskAssessmentId}. Run assess-gaps first.`,
+    );
+  }
+
+  const testMapping = findTestMappingById(
+    config.paths.database,
+    riskAssessment.testMappingId,
+  );
+
+  if (!testMapping) {
+    throw new Error(
+      `Test mapping not found for id=${riskAssessment.testMappingId}. Run map-tests first.`,
+    );
+  }
+
+  const changeAnalysis = findChangeAnalysisById(
+    config.paths.database,
+    testMapping.changeAnalysisId,
+  );
+
+  if (!changeAnalysis) {
+    throw new Error(
+      `Change analysis not found for id=${testMapping.changeAnalysisId}. Run discover-context first.`,
+    );
+  }
+
+  const prIntake = findPrIntakeById(
+    config.paths.database,
+    testMapping.prIntakeId,
+  );
+
+  if (!prIntake) {
+    throw new Error(
+      `PR intake not found for id=${testMapping.prIntakeId}. Run pr-intake first.`,
+    );
+  }
+
+  return {
+    riskAssessment,
+    testMapping,
+    changeAnalysis,
+    prIntake,
+  };
+}
+
+function groupCoverageGapsByFile(
+  coverageGaps: readonly CoverageGapEntry[],
+): Map<string, CoverageGapEntry[]> {
+  const map = new Map<string, CoverageGapEntry[]>();
+
+  for (const gap of coverageGaps) {
+    const list = map.get(gap.changedFilePath) ?? [];
+    list.push(gap);
+    map.set(gap.changedFilePath, list);
+  }
+
+  return map;
+}
+
+function buildAllocationItem(input: {
+  readonly riskAssessmentId: number;
+  readonly fileAnalysis: AllocationContext["changeAnalysis"]["fileAnalyses"][number];
+  readonly gap: CoverageGapEntry;
+  readonly riskScore: PersistedRiskAssessment["riskScores"][number] | null;
+  readonly existingTestLayers: readonly TestLayer[];
+  readonly reviewComments: readonly string[];
+}): AllocationItem {
+  const categories = uniqueCategories(
+    input.fileAnalysis.categories.map((category) => category.category),
+  );
+  const riskSignals = buildRiskSignals(
+    input.fileAnalysis.path,
+    [input.gap],
+    input.riskScore,
+    input.existingTestLayers,
+    input.reviewComments,
+  );
+  const destination = decideDestination(
+    input.fileAnalysis,
+    input.gap,
+    input.riskScore,
+  );
+  const riskLevel = deriveRiskLevel(input.riskScore, [input.gap]);
+
+  return {
+    riskAssessmentId: input.riskAssessmentId,
+    title: buildAllocationTitle(destination, input.fileAnalysis.path, [
+      input.gap.aspect,
+    ]),
+    changedFilePaths: [input.fileAnalysis.path],
+    riskLevel,
+    recommendedDestination: destination,
+    confidence: deriveConfidence(destination, [input.gap]),
+    rationale: buildRationale(
+      destination,
+      input.fileAnalysis.path,
+      [input.gap.aspect],
+      riskSignals,
+    ),
+    sourceSignals: {
+      categories,
+      existingTestLayers: [...input.existingTestLayers],
+      gapAspects: [input.gap.aspect],
+      reviewComments: [...input.reviewComments],
+      riskSignals,
+    },
+  };
+}
+
+function decideDestination(
+  fileAnalysis: AllocationContext["changeAnalysis"]["fileAnalyses"][number],
+  gap: CoverageGapEntry,
+  riskScore: PersistedRiskAssessment["riskScores"][number] | null,
+): AllocationDestination {
+  const categories = new Set(
+    fileAnalysis.categories.map((category) => category.category),
+  );
+  const riskLevel = deriveRiskLevel(riskScore, [gap]);
+
+  if (gap.status === "covered") {
+    return "skip";
+  }
+
+  if (hasAnyCategory(categories, ["permission", "feature-flag"])) {
+    return "review";
+  }
+
+  if (hasAnyCategory(categories, ["validation", "state-transition"])) {
+    return "unit";
+  }
+
+  if (hasAnyCategory(categories, ["api", "schema", "cross-service", "async"])) {
+    return "integration";
+  }
+
+  if (hasAnyCategory(categories, ["ui"])) {
+    return isFlowPath(fileAnalysis.path) ? "e2e" : "visual";
+  }
+
+  if (riskLevel === "low" && gap.aspect === "happy-path") {
+    return "dev-box";
+  }
+
+  return "manual-exploration";
+}
+
+function deriveRiskLevel(
+  riskScore: PersistedRiskAssessment["riskScores"][number] | null,
+  gaps: readonly CoverageGapEntry[],
+): ExplorationPriority {
+  const scoreLevel = riskScore
+    ? riskScore.overallRisk >= 0.66
+      ? "high"
+      : riskScore.overallRisk >= 0.33
+        ? "medium"
+        : "low"
+    : "low";
+
+  const gapLevel = gaps.reduce<ExplorationPriority>((current, gap) => {
+    if (gap.explorationPriority === "high") {
+      return "high";
+    }
+    if (gap.explorationPriority === "medium" && current === "low") {
+      return "medium";
+    }
+    return current;
+  }, "low");
+
+  return compareRiskLevel(scoreLevel, gapLevel) >= 0 ? scoreLevel : gapLevel;
+}
+
+function compareRiskLevel(
+  left: ExplorationPriority,
+  right: ExplorationPriority,
+): number {
+  const order: Record<ExplorationPriority, number> = {
+    high: 3,
+    medium: 2,
+    low: 1,
+  };
+
+  return order[left] - order[right];
+}
+
+function deriveConfidence(
+  destination: AllocationDestination,
+  gaps: readonly CoverageGapEntry[],
+): number {
+  if (destination === "skip") {
+    return 0.95;
+  }
+
+  if (destination === "manual-exploration") {
+    return gaps.some((gap) => gap.status === "partial") ? 0.55 : 0.35;
+  }
+
+  if (destination === "dev-box") {
+    return 0.75;
+  }
+
+  return gaps.some((gap) => gap.status === "partial") ? 0.6 : 0.86;
+}
+
+function buildAllocationTitle(
+  destination: AllocationDestination,
+  filePath: string,
+  gapAspects: readonly CoverageAspect[],
+): string {
+  const aspects = gapAspects.join(", ");
+
+  switch (destination) {
+    case "review":
+      return `Review ${filePath} (${aspects})`;
+    case "unit":
+      return `Unit coverage for ${filePath} (${aspects})`;
+    case "integration":
+      return `Integration coverage for ${filePath} (${aspects})`;
+    case "e2e":
+      return `End-to-end coverage for ${filePath} (${aspects})`;
+    case "visual":
+      return `Visual coverage for ${filePath} (${aspects})`;
+    case "dev-box":
+      return `Dev-box smoke check for ${filePath} (${aspects})`;
+    case "manual-exploration":
+      return `Manual exploration for ${filePath} (${aspects})`;
+    case "skip":
+      return `Already covered for ${filePath} (${aspects})`;
+  }
+}
+
+function buildRationale(
+  destination: AllocationDestination,
+  filePath: string,
+  gapAspects: readonly CoverageAspect[],
+  riskSignals: readonly string[],
+): string {
+  const aspects = gapAspects.join(", ");
+  const signalSummary = riskSignals.slice(0, 3).join(", ");
+
+  switch (destination) {
+    case "review":
+      return `Code review should verify ${filePath} before QA handoff. Signals: ${signalSummary}`;
+    case "unit":
+      return `Deterministic logic in ${filePath} should be pinned with unit tests. Signals: ${signalSummary}`;
+    case "integration":
+      return `Boundary behavior in ${filePath} is better covered with integration tests. Signals: ${signalSummary}`;
+    case "e2e":
+      return `Primary user flow in ${filePath} should be exercised end-to-end. Signals: ${signalSummary}`;
+    case "visual":
+      return `Rendering differences in ${filePath} are best covered by visual regression. Signals: ${signalSummary}`;
+    case "dev-box":
+      return `Implementer should run a quick smoke check for ${filePath} before QA handoff. Signals: ${signalSummary}`;
+    case "manual-exploration":
+      return `This remains a manual exploration topic because ${filePath} still has stateful or ambiguous risk. Aspects: ${aspects}`;
+    case "skip":
+      return `Existing confirmed tests already cover ${filePath}. Aspects: ${aspects}`;
+  }
+}
+
+function buildRiskSignals(
+  filePath: string,
+  gaps: readonly CoverageGapEntry[],
+  riskScore: PersistedRiskAssessment["riskScores"][number] | null,
+  existingTestLayers: readonly TestLayer[],
+  reviewComments: readonly string[],
+): string[] {
+  const signals: string[] = [];
+
+  if (riskScore) {
+    signals.push(`risk:${riskScore.overallRisk.toFixed(3)}`);
+  }
+
+  for (const gap of gaps) {
+    signals.push(`gap:${gap.aspect}:${gap.status}`);
+  }
+
+  for (const layer of existingTestLayers) {
+    signals.push(`layer:${layer}`);
+  }
+
+  for (const comment of reviewComments) {
+    signals.push(`review:${comment}`);
+  }
+
+  if (signals.length === 0) {
+    signals.push(`file:${filePath}`);
+  }
+
+  return signals;
+}
+
+function deriveExistingTestLayers(
+  filePath: string,
+  testMapping: PersistedTestMapping,
+): readonly TestLayer[] {
+  const relatedTestAssets = testMapping.testAssets.filter((asset) =>
+    asset.relatedTo.includes(filePath),
+  );
+  const layers = new Set<TestLayer>();
+
+  for (const asset of relatedTestAssets) {
+    layers.add(asset.layer);
+    for (const summary of testMapping.testSummaries) {
+      if (summary.testAssetPath === asset.path) {
+        layers.add(summary.layer);
+      }
+    }
+  }
+
+  return [...layers];
+}
+
+function deriveReviewComments(
+  filePath: string,
+  prIntake: PersistedPrIntake,
+): readonly string[] {
+  return prIntake.reviewComments
+    .filter((comment) => comment.path === filePath)
+    .map((comment) => `${comment.author}: ${comment.body}`);
+}
+
+function uniqueCategories(
+  categories: readonly ChangeCategory[],
+): ChangeCategory[] {
+  return [...new Set(categories)];
+}
+
+function hasAnyCategory(
+  categories: ReadonlySet<ChangeCategory>,
+  targets: readonly ChangeCategory[],
+): boolean {
+  return targets.some((target) => categories.has(target));
+}
+
+function isFlowPath(filePath: string): boolean {
+  return (
+    /\/(pages|views|routes|screens|flows)\//i.test(filePath) ||
+    /(?:checkout|login|signup|cart|profile)/i.test(filePath)
+  );
+}
+
+function countItemsByDestination(
+  items: readonly PersistedAllocationItem[],
+): AllocationDestinationCounts {
+  const counts = createEmptyAllocationDestinationCounts();
+
+  for (const item of items) {
+    counts[item.recommendedDestination] += 1;
+  }
+
+  return counts;
+}

--- a/src/exploratory-testing/tools/handoff.ts
+++ b/src/exploratory-testing/tools/handoff.ts
@@ -1,0 +1,497 @@
+import {
+  type PersistedAllocationItem,
+  type PersistedPrIntake,
+  type PersistedSession,
+  countAllocationItemsByDestination,
+  findPrIntakeById,
+  findRiskAssessmentById,
+  findSession,
+  findSessionChartersById,
+  findTestMappingById,
+  listAllocationItems,
+} from "../db/workspace-repository";
+import { escapePipe } from "../lib/markdown";
+import type { AllocationDestinationCounts } from "../models/allocation";
+import type { ResolvedPluginConfig } from "../models/config";
+import type { CreatedComment, CreatedIssue } from "../models/github-issue";
+import {
+  type AddCommentInput,
+  type CreateIssueInput,
+  type EditIssueInput,
+  addIssueComment,
+  createIssue,
+  editIssueBody,
+} from "../scm/github-issues";
+import { readPluginConfig } from "./config";
+import { generateTriageReport } from "./triage-findings";
+
+export type { AddCommentInput, CreateIssueInput, EditIssueInput };
+
+export type HandoffGenerateInput = {
+  readonly riskAssessmentId: number;
+  readonly configPath?: string;
+  readonly manifestPath?: string;
+};
+
+export type HandoffPublishInput = HandoffGenerateInput & {
+  readonly title?: string;
+  readonly labels?: readonly string[];
+  readonly assignees?: readonly string[];
+};
+
+export type HandoffUpdateInput = HandoffGenerateInput & {
+  readonly issueNumber: number;
+};
+
+export type HandoffFindingsInput = {
+  readonly issueNumber: number;
+  readonly sessionId: number;
+  readonly configPath?: string;
+  readonly manifestPath?: string;
+};
+
+export type HandoffSections = {
+  readonly alreadyCovered: readonly PersistedAllocationItem[];
+  readonly shouldAutomate: readonly PersistedAllocationItem[];
+  readonly manualExploration: readonly PersistedAllocationItem[];
+};
+
+export type HandoffSummary = {
+  readonly totalItems: number;
+  readonly manualCount: number;
+  readonly automateCount: number;
+  readonly coveredCount: number;
+};
+
+export type HandoffMarkdownResult = {
+  readonly riskAssessmentId: number;
+  readonly repository: string;
+  readonly markdown: string;
+  readonly sections: HandoffSections;
+  readonly counts: AllocationDestinationCounts;
+  readonly summary: HandoffSummary;
+};
+
+export type CreateHandoffIssueResult = {
+  readonly markdown: HandoffMarkdownResult;
+  readonly issue: CreatedIssue;
+};
+
+export type CreateHandoffIssueRawResult = {
+  readonly issue: CreatedIssue;
+};
+
+export type UpdateHandoffIssueResult = {
+  readonly markdown: HandoffMarkdownResult;
+  readonly issueNumber: number;
+};
+
+export type AddHandoffCommentResult = {
+  readonly comment: CreatedComment;
+  readonly body: string;
+};
+
+export type AddHandoffCommentRawResult = {
+  readonly comment: CreatedComment;
+};
+
+type HandoffContext = {
+  readonly prIntake: PersistedPrIntake;
+  readonly items: readonly PersistedAllocationItem[];
+  readonly counts: AllocationDestinationCounts;
+};
+
+export async function generateHandoffMarkdown(
+  input: HandoffGenerateInput,
+): Promise<HandoffMarkdownResult> {
+  const context = await resolveHandoffContext(input);
+  const sections = groupBySection(context.items);
+  const summary = buildHandoffSummary(context.counts);
+
+  return {
+    riskAssessmentId: input.riskAssessmentId,
+    repository: context.prIntake.repository,
+    markdown: renderHandoffMarkdown(context.prIntake, input.riskAssessmentId, {
+      sections,
+      summary,
+    }),
+    sections,
+    counts: context.counts,
+    summary,
+  };
+}
+
+export async function runCreateHandoffIssue(
+  input: HandoffPublishInput,
+): Promise<CreateHandoffIssueResult> {
+  const markdown = await generateHandoffMarkdown(input);
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+
+  const issue = await createIssue({
+    repositoryRoot: config.workspaceRoot,
+    repository: markdown.repository,
+    title:
+      input.title ??
+      `QA: PR #${extractPrNumber(markdown.markdown)} — handoff checklist`,
+    body: markdown.markdown,
+    labels: input.labels,
+    assignees: input.assignees,
+  });
+
+  return { markdown, issue };
+}
+
+export async function runCreateHandoffIssueRaw(
+  input: CreateIssueInput,
+): Promise<CreateHandoffIssueRawResult> {
+  const issue = await createIssue(input);
+  return { issue };
+}
+
+export async function runUpdateHandoffIssue(
+  input: HandoffUpdateInput,
+): Promise<UpdateHandoffIssueResult> {
+  const markdown = await generateHandoffMarkdown(input);
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+
+  await editIssueBody({
+    repositoryRoot: config.workspaceRoot,
+    repository: markdown.repository,
+    issueNumber: input.issueNumber,
+    body: markdown.markdown,
+  });
+
+  return {
+    markdown,
+    issueNumber: input.issueNumber,
+  };
+}
+
+export async function runUpdateHandoffIssueBody(
+  input: EditIssueInput,
+): Promise<void> {
+  await editIssueBody(input);
+}
+
+export async function runAddHandoffComment(
+  input: HandoffFindingsInput,
+): Promise<AddHandoffCommentResult> {
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+  const context = resolveFindingsContext(config, input.sessionId);
+  const report = await generateTriageReport({
+    sessionId: input.sessionId,
+    config,
+  });
+  const body = renderFindingsComment(context.session, report);
+
+  const comment = await addIssueComment({
+    repositoryRoot: config.workspaceRoot,
+    repository: context.prIntake.repository,
+    issueNumber: input.issueNumber,
+    body,
+  });
+
+  return { comment, body };
+}
+
+export async function runAddHandoffCommentRaw(
+  input: AddCommentInput,
+): Promise<AddHandoffCommentRawResult> {
+  const comment = await addIssueComment(input);
+  return { comment };
+}
+
+export function groupBySection(
+  items: readonly PersistedAllocationItem[],
+): HandoffSections {
+  return {
+    alreadyCovered: items.filter(
+      (item) =>
+        item.recommendedDestination === "skip" ||
+        item.recommendedDestination === "review",
+    ),
+    shouldAutomate: items.filter((item) =>
+      ["unit", "integration", "e2e", "visual"].includes(
+        item.recommendedDestination,
+      ),
+    ),
+    manualExploration: items.filter((item) =>
+      ["manual-exploration", "dev-box"].includes(item.recommendedDestination),
+    ),
+  };
+}
+
+export function renderHandoffMarkdown(
+  prIntake: PersistedPrIntake,
+  riskAssessmentId: number,
+  input: {
+    readonly sections: HandoffSections;
+    readonly summary: HandoffSummary;
+  },
+): string {
+  const prUrl =
+    prIntake.provider === "github"
+      ? `https://github.com/${prIntake.repository}/pull/${prIntake.prNumber}`
+      : `${prIntake.repository}#${prIntake.prNumber}`;
+
+  return [
+    `## ${escapePipe(`QA Handoff — PR #${prIntake.prNumber}: ${prIntake.title}`)}`,
+    "",
+    `**PR**: ${prUrl}`,
+    `**Author**: ${escapePipe(prIntake.author)}`,
+    `**Branch**: ${escapePipe(prIntake.headBranch)} -> ${escapePipe(prIntake.baseBranch)}`,
+    `**Generated**: ${new Date().toISOString()}`,
+    "",
+    "### Summary",
+    "",
+    escapePipe(prIntake.title),
+    "",
+    `- Total items: ${input.summary.totalItems}`,
+    `- Manual exploration: ${input.summary.manualCount}`,
+    `- Should automate: ${input.summary.automateCount}`,
+    `- Already covered: ${input.summary.coveredCount}`,
+    "",
+    "---",
+    "",
+    "### ✅ Already Covered",
+    ...renderCoveredSection(input.sections.alreadyCovered),
+    "",
+    "---",
+    "",
+    "### 🔧 Should Automate",
+    ...renderAutomationSection(input.sections.shouldAutomate),
+    "",
+    "---",
+    "",
+    "### 🔍 Manual Exploration Required",
+    ...renderManualSection(input.sections.manualExploration),
+    "",
+    "### Notes",
+    "",
+    `- Risk assessment ID: ${riskAssessmentId}`,
+    "- Generated by exploratory-testing-plugin",
+    "",
+  ].join("\n");
+}
+
+export function renderFindingsComment(
+  session: PersistedSession,
+  report: Awaited<ReturnType<typeof generateTriageReport>>,
+): string {
+  const lines = [
+    `## ${escapePipe(`Exploration Findings — Session: ${session.charterTitle}`)}`,
+    "",
+    `**Charter**: ${escapePipe(session.charterTitle)}`,
+    `**Status**: ${session.status}`,
+    `**Session ID**: ${session.id}`,
+    "",
+    "### Findings",
+    "",
+  ];
+
+  if (report.findings.length === 0) {
+    lines.push("_No findings from this session._", "");
+    return lines.join("\n");
+  }
+
+  for (const finding of report.findings) {
+    lines.push(
+      `#### ${escapePipe(finding.title)}`,
+      "",
+      `- **Type**: ${finding.type}`,
+      `- **Severity**: ${finding.severity}`,
+      `- **Description**: ${escapePipe(finding.description)}`,
+    );
+
+    if (finding.type === "automation-candidate") {
+      lines.push(
+        `- **Recommended layer**: ${finding.recommendedTestLayer ?? "—"}`,
+        `- **Rationale**: ${escapePipe(finding.automationRationale ?? "")}`,
+      );
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function renderCoveredSection(
+  items: readonly PersistedAllocationItem[],
+): readonly string[] {
+  if (items.length === 0) {
+    return ["", "_No items in this category._"];
+  }
+
+  return [
+    "",
+    ...items.map(
+      (item) =>
+        `- **${escapePipe(item.title)}** — ${escapePipe(item.rationale)} _(${item.recommendedDestination})_`,
+    ),
+  ];
+}
+
+function renderAutomationSection(
+  items: readonly PersistedAllocationItem[],
+): readonly string[] {
+  if (items.length === 0) {
+    return ["", "_No automation recommendations._"];
+  }
+
+  return [
+    "",
+    ...items.map(
+      (item) =>
+        `- [ ] **${escapePipe(item.title)}** -> **${item.recommendedDestination}** — ${escapePipe(item.rationale)}`,
+    ),
+  ];
+}
+
+function renderManualSection(
+  items: readonly PersistedAllocationItem[],
+): readonly string[] {
+  if (items.length === 0) {
+    return ["", "_No manual exploration needed._"];
+  }
+
+  return [
+    "",
+    ...items.map((item) => {
+      const prefix =
+        item.recommendedDestination === "dev-box" ? "[dev-box] " : "";
+      return `- [ ] **${escapePipe(prefix + item.title)}** _(${item.riskLevel})_ — ${escapePipe(item.rationale)}`;
+    }),
+  ];
+}
+
+function buildHandoffSummary(
+  counts: AllocationDestinationCounts,
+): HandoffSummary {
+  return {
+    totalItems: Object.values(counts).reduce((sum, count) => sum + count, 0),
+    manualCount: counts["manual-exploration"] + counts["dev-box"],
+    automateCount:
+      counts.unit + counts.integration + counts.e2e + counts.visual,
+    coveredCount: counts.skip + counts.review,
+  };
+}
+
+async function resolveHandoffContext(
+  input: HandoffGenerateInput,
+): Promise<HandoffContext> {
+  const config = await readPluginConfig(input.configPath, input.manifestPath);
+  const riskAssessment = findRiskAssessmentById(
+    config.paths.database,
+    input.riskAssessmentId,
+  );
+
+  if (!riskAssessment) {
+    throw new Error(
+      `Risk assessment not found for id=${input.riskAssessmentId}. Run assess-gaps first.`,
+    );
+  }
+
+  const testMapping = findTestMappingById(
+    config.paths.database,
+    riskAssessment.testMappingId,
+  );
+
+  if (!testMapping) {
+    throw new Error(
+      `Test mapping not found for id=${riskAssessment.testMappingId}.`,
+    );
+  }
+
+  const prIntake = findPrIntakeById(
+    config.paths.database,
+    testMapping.prIntakeId,
+  );
+
+  if (!prIntake) {
+    throw new Error(`PR intake not found for id=${testMapping.prIntakeId}.`);
+  }
+
+  const items = listAllocationItems(
+    config.paths.database,
+    input.riskAssessmentId,
+  );
+  const counts = countAllocationItemsByDestination(
+    config.paths.database,
+    input.riskAssessmentId,
+  );
+
+  return {
+    prIntake,
+    items,
+    counts,
+  };
+}
+
+function resolveFindingsContext(
+  config: ResolvedPluginConfig,
+  sessionId: number,
+): {
+  readonly session: PersistedSession;
+  readonly prIntake: PersistedPrIntake;
+} {
+  const session = findSession(config.paths.database, sessionId);
+
+  if (!session) {
+    throw new Error(`Session not found: id=${sessionId}`);
+  }
+
+  const charters = findSessionChartersById(
+    config.paths.database,
+    session.sessionChartersId,
+  );
+
+  if (!charters) {
+    throw new Error(
+      `Session charters not found for id=${session.sessionChartersId}.`,
+    );
+  }
+
+  const riskAssessment = findRiskAssessmentById(
+    config.paths.database,
+    charters.riskAssessmentId,
+  );
+
+  if (!riskAssessment) {
+    throw new Error(
+      `Risk assessment not found for id=${charters.riskAssessmentId}.`,
+    );
+  }
+
+  const testMapping = findTestMappingById(
+    config.paths.database,
+    riskAssessment.testMappingId,
+  );
+
+  if (!testMapping) {
+    throw new Error(
+      `Test mapping not found for id=${riskAssessment.testMappingId}.`,
+    );
+  }
+
+  const prIntake = findPrIntakeById(
+    config.paths.database,
+    testMapping.prIntakeId,
+  );
+
+  if (!prIntake) {
+    throw new Error(`PR intake not found for id=${testMapping.prIntakeId}.`);
+  }
+
+  return { session, prIntake };
+}
+
+function extractPrNumber(markdown: string): number {
+  const match = markdown.match(/PR #(\d+)/);
+
+  if (!match) {
+    return 0;
+  }
+
+  return Number(match[1]);
+}

--- a/tests/unit/allocate-tool.test.ts
+++ b/tests/unit/allocate-tool.test.ts
@@ -1,0 +1,549 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  saveChangeAnalysis,
+  savePrIntake,
+  saveRiskAssessment,
+  saveTestMapping,
+} from "../../src/exploratory-testing/db/workspace-repository";
+import type { ChangeAnalysisResult } from "../../src/exploratory-testing/models/change-analysis";
+import type { PrMetadata } from "../../src/exploratory-testing/models/pr-intake";
+import type { RiskAssessmentResult } from "../../src/exploratory-testing/models/risk-assessment";
+import type { TestMappingResult } from "../../src/exploratory-testing/models/test-mapping";
+import {
+  buildAllocationItems,
+  runAllocate,
+  summarizeAllocation,
+} from "../../src/exploratory-testing/tools/allocate";
+import { initializeWorkspace } from "../../src/exploratory-testing/tools/setup";
+import {
+  type TestWorkspace,
+  cleanupTestWorkspace,
+  createTestWorkspace,
+} from "../helpers/workspace";
+
+const workspaces: string[] = [];
+
+function createSamplePrMetadata(): PrMetadata {
+  return {
+    provider: "github",
+    repository: "owner/repo",
+    prNumber: 42,
+    title: "Shift-left allocation sample",
+    description: "Exercise multiple allocation destinations",
+    author: "alice",
+    baseBranch: "main",
+    headBranch: "feature/allocation",
+    headSha: "abc1234",
+    linkedIssues: [],
+    changedFiles: [
+      {
+        path: "src/middleware/auth.ts",
+        status: "modified",
+        additions: 20,
+        deletions: 2,
+        previousPath: null,
+      },
+      {
+        path: "src/validators/userInput.ts",
+        status: "modified",
+        additions: 18,
+        deletions: 1,
+        previousPath: null,
+      },
+      {
+        path: "src/clients/paymentGateway.ts",
+        status: "modified",
+        additions: 28,
+        deletions: 4,
+        previousPath: null,
+      },
+      {
+        path: "src/pages/Checkout.tsx",
+        status: "modified",
+        additions: 32,
+        deletions: 6,
+        previousPath: null,
+      },
+      {
+        path: "src/components/Button.tsx",
+        status: "modified",
+        additions: 26,
+        deletions: 3,
+        previousPath: null,
+      },
+      {
+        path: "scripts/format.ts",
+        status: "modified",
+        additions: 5,
+        deletions: 0,
+        previousPath: null,
+      },
+      {
+        path: "src/utility.ts",
+        status: "modified",
+        additions: 140,
+        deletions: 12,
+        previousPath: null,
+      },
+      {
+        path: "src/features/flags.ts",
+        status: "modified",
+        additions: 12,
+        deletions: 1,
+        previousPath: null,
+      },
+    ],
+    reviewComments: [
+      {
+        author: "bob",
+        body: "Please verify auth guard behavior.",
+        path: "src/middleware/auth.ts",
+        createdAt: "2026-04-01T00:00:00Z",
+      },
+    ],
+    fetchedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleChangeAnalysis(prIntakeId: number): ChangeAnalysisResult {
+  return {
+    prIntakeId,
+    fileAnalyses: [
+      {
+        path: "src/middleware/auth.ts",
+        status: "modified",
+        additions: 20,
+        deletions: 2,
+        categories: [
+          { category: "permission", confidence: 0.9, reason: "Auth guard" },
+        ],
+      },
+      {
+        path: "src/validators/userInput.ts",
+        status: "modified",
+        additions: 18,
+        deletions: 1,
+        categories: [
+          { category: "validation", confidence: 0.9, reason: "Validator" },
+        ],
+      },
+      {
+        path: "src/clients/paymentGateway.ts",
+        status: "modified",
+        additions: 28,
+        deletions: 4,
+        categories: [
+          { category: "api", confidence: 0.85, reason: "Client boundary" },
+          { category: "async", confidence: 0.8, reason: "Retry handling" },
+          {
+            category: "cross-service",
+            confidence: 0.8,
+            reason: "External gateway",
+          },
+        ],
+      },
+      {
+        path: "src/pages/Checkout.tsx",
+        status: "modified",
+        additions: 32,
+        deletions: 6,
+        categories: [
+          { category: "ui", confidence: 0.8, reason: "Page component" },
+        ],
+      },
+      {
+        path: "src/components/Button.tsx",
+        status: "modified",
+        additions: 26,
+        deletions: 3,
+        categories: [
+          { category: "ui", confidence: 0.8, reason: "Component" },
+          {
+            category: "shared-component",
+            confidence: 0.8,
+            reason: "Shared UI",
+          },
+        ],
+      },
+      {
+        path: "scripts/format.ts",
+        status: "modified",
+        additions: 5,
+        deletions: 0,
+        categories: [],
+      },
+      {
+        path: "src/utility.ts",
+        status: "modified",
+        additions: 140,
+        deletions: 12,
+        categories: [],
+      },
+      {
+        path: "src/features/flags.ts",
+        status: "modified",
+        additions: 12,
+        deletions: 1,
+        categories: [
+          { category: "feature-flag", confidence: 0.9, reason: "Flag config" },
+        ],
+      },
+    ],
+    relatedCodes: [],
+    viewpointSeeds: [
+      { viewpoint: "functional-user-flow", seeds: ["checkout", "login"] },
+    ],
+    summary: "Multiple files analyzed",
+    analyzedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleTestMapping(
+  prIntakeId: number,
+  changeAnalysisId: number,
+): TestMappingResult {
+  return {
+    prIntakeId,
+    changeAnalysisId,
+    testAssets: [
+      {
+        path: "tests/unit/flags.test.ts",
+        layer: "unit",
+        relatedTo: ["src/features/flags.ts"],
+        confidence: 0.9,
+      },
+      {
+        path: "tests/unit/format.test.ts",
+        layer: "unit",
+        relatedTo: ["scripts/format.ts"],
+        confidence: 0.9,
+      },
+    ],
+    testSummaries: [
+      {
+        testAssetPath: "tests/unit/flags.test.ts",
+        layer: "unit",
+        coveredAspects: [
+          "happy-path",
+          "error-path",
+          "permission",
+          "state-transition",
+        ],
+        coverageConfidence: "confirmed",
+        description: "Feature flag behavior is covered",
+      },
+      {
+        testAssetPath: "tests/unit/format.test.ts",
+        layer: "unit",
+        coveredAspects: [
+          "error-path",
+          "boundary",
+          "permission",
+          "state-transition",
+          "mock-fixture",
+        ],
+        coverageConfidence: "confirmed",
+        description: "Formatting edge cases are covered",
+      },
+    ],
+    coverageGapMap: [
+      {
+        changedFilePath: "src/middleware/auth.ts",
+        aspect: "permission",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/validators/userInput.ts",
+        aspect: "boundary",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/clients/paymentGateway.ts",
+        aspect: "boundary",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/clients/paymentGateway.ts",
+        aspect: "state-transition",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/pages/Checkout.tsx",
+        aspect: "happy-path",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/components/Button.tsx",
+        aspect: "happy-path",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "medium",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "happy-path",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "error-path",
+        status: "covered",
+        coveredBy: ["tests/unit/format.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "boundary",
+        status: "covered",
+        coveredBy: ["tests/unit/format.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "permission",
+        status: "covered",
+        coveredBy: ["tests/unit/format.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "state-transition",
+        status: "covered",
+        coveredBy: ["tests/unit/format.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        aspect: "mock-fixture",
+        status: "covered",
+        coveredBy: ["tests/unit/format.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "src/utility.ts",
+        aspect: "happy-path",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+      {
+        changedFilePath: "src/features/flags.ts",
+        aspect: "permission",
+        status: "covered",
+        coveredBy: ["tests/unit/flags.test.ts"],
+        explorationPriority: "low",
+      },
+      {
+        changedFilePath: "src/features/flags.ts",
+        aspect: "state-transition",
+        status: "covered",
+        coveredBy: ["tests/unit/flags.test.ts"],
+        explorationPriority: "low",
+      },
+    ],
+    missingLayers: ["e2e", "visual"],
+    mappedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleRiskAssessment(
+  testMappingId: number,
+): RiskAssessmentResult {
+  return {
+    testMappingId,
+    riskScores: [
+      {
+        changedFilePath: "src/middleware/auth.ts",
+        overallRisk: 0.82,
+        factors: [{ factor: "permission", weight: 0.5, contribution: 0.41 }],
+      },
+      {
+        changedFilePath: "src/validators/userInput.ts",
+        overallRisk: 0.76,
+        factors: [{ factor: "validation", weight: 0.5, contribution: 0.38 }],
+      },
+      {
+        changedFilePath: "src/clients/paymentGateway.ts",
+        overallRisk: 0.88,
+        factors: [{ factor: "cross-service", weight: 0.5, contribution: 0.44 }],
+      },
+      {
+        changedFilePath: "src/pages/Checkout.tsx",
+        overallRisk: 0.71,
+        factors: [{ factor: "ui", weight: 0.5, contribution: 0.36 }],
+      },
+      {
+        changedFilePath: "src/components/Button.tsx",
+        overallRisk: 0.65,
+        factors: [
+          { factor: "shared-component", weight: 0.5, contribution: 0.33 },
+        ],
+      },
+      {
+        changedFilePath: "scripts/format.ts",
+        overallRisk: 0.22,
+        factors: [{ factor: "small-change", weight: 0.5, contribution: 0.08 }],
+      },
+      {
+        changedFilePath: "src/utility.ts",
+        overallRisk: 0.93,
+        factors: [
+          { factor: "uncovered-aspects", weight: 0.5, contribution: 0.46 },
+        ],
+      },
+      {
+        changedFilePath: "src/features/flags.ts",
+        overallRisk: 0.3,
+        factors: [{ factor: "feature-flag", weight: 0.5, contribution: 0.15 }],
+      },
+    ],
+    frameworkSelections: [],
+    explorationThemes: [],
+    assessedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+describe("allocate tool", () => {
+  afterEach(async () => {
+    await Promise.all(workspaces.splice(0).map(cleanupTestWorkspace));
+  });
+
+  async function setupWorkspace(): Promise<
+    TestWorkspace & { databasePath: string }
+  > {
+    const workspace = await createTestWorkspace();
+    workspaces.push(workspace.root);
+    const result = await initializeWorkspace(
+      workspace.configPath,
+      workspace.manifestPath,
+    );
+    return { ...workspace, databasePath: result.databasePath };
+  }
+
+  function seedAllocationPipeline(databasePath: string): number {
+    const prIntake = savePrIntake(databasePath, createSamplePrMetadata());
+    const changeAnalysis = saveChangeAnalysis(
+      databasePath,
+      createSampleChangeAnalysis(prIntake.id),
+    );
+    const testMapping = saveTestMapping(
+      databasePath,
+      createSampleTestMapping(prIntake.id, changeAnalysis.id),
+    );
+    const riskAssessment = saveRiskAssessment(
+      databasePath,
+      createSampleRiskAssessment(testMapping.id),
+    );
+
+    return riskAssessment.id;
+  }
+
+  it("builds allocation items that cover the main destinations", async () => {
+    const workspace = await setupWorkspace();
+    const prIntake = savePrIntake(
+      workspace.databasePath,
+      createSamplePrMetadata(),
+    );
+    const changeAnalysis = saveChangeAnalysis(
+      workspace.databasePath,
+      createSampleChangeAnalysis(prIntake.id),
+    );
+    const testMapping = saveTestMapping(
+      workspace.databasePath,
+      createSampleTestMapping(prIntake.id, changeAnalysis.id),
+    );
+    const riskAssessment = saveRiskAssessment(
+      workspace.databasePath,
+      createSampleRiskAssessment(testMapping.id),
+    );
+    const context = {
+      riskAssessment,
+      testMapping,
+      changeAnalysis,
+      prIntake,
+    };
+
+    const items = buildAllocationItems(context);
+    expect(items.some((item) => item.recommendedDestination === "review")).toBe(
+      true,
+    );
+    expect(items.some((item) => item.recommendedDestination === "unit")).toBe(
+      true,
+    );
+    expect(
+      items.some((item) => item.recommendedDestination === "integration"),
+    ).toBe(true);
+    expect(items.some((item) => item.recommendedDestination === "e2e")).toBe(
+      true,
+    );
+    expect(items.some((item) => item.recommendedDestination === "visual")).toBe(
+      true,
+    );
+    expect(
+      items.some((item) => item.recommendedDestination === "dev-box"),
+    ).toBe(true);
+    expect(
+      items.some(
+        (item) => item.recommendedDestination === "manual-exploration",
+      ),
+    ).toBe(true);
+    expect(items.some((item) => item.recommendedDestination === "skip")).toBe(
+      true,
+    );
+  });
+
+  it("runs allocation end to end and persists the generated items", async () => {
+    const workspace = await setupWorkspace();
+    const riskAssessmentId = seedAllocationPipeline(workspace.databasePath);
+
+    const result = await runAllocate({
+      riskAssessmentId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    expect(result.items.length).toBeGreaterThanOrEqual(8);
+    expect(result.destinationCounts.review).toBeGreaterThan(0);
+    expect(result.destinationCounts.unit).toBeGreaterThan(0);
+    expect(result.destinationCounts.integration).toBeGreaterThan(0);
+    expect(result.destinationCounts.e2e).toBeGreaterThan(0);
+    expect(result.destinationCounts.visual).toBeGreaterThan(0);
+    expect(result.destinationCounts["dev-box"]).toBeGreaterThan(0);
+    expect(result.destinationCounts["manual-exploration"]).toBeGreaterThan(0);
+    expect(result.destinationCounts.skip).toBeGreaterThan(0);
+  });
+
+  it("summarizes allocation with representative items", async () => {
+    const workspace = await setupWorkspace();
+    const riskAssessmentId = seedAllocationPipeline(workspace.databasePath);
+
+    await runAllocate({
+      riskAssessmentId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    const summary = await summarizeAllocation({
+      riskAssessmentId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    expect(summary.totalItems).toBeGreaterThan(0);
+    expect(summary.representativeItems.length).toBeGreaterThan(0);
+    expect(summary.destinationCounts.review).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/allocation-model.test.ts
+++ b/tests/unit/allocation-model.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  allocationDestinationSchema,
+  allocationItemSchema,
+  allocationSourceSignalsSchema,
+  createEmptyAllocationDestinationCounts,
+} from "../../src/exploratory-testing/models/allocation";
+
+describe("allocationDestinationSchema", () => {
+  it("accepts the supported destinations", () => {
+    const destinations = [
+      "review",
+      "unit",
+      "integration",
+      "e2e",
+      "visual",
+      "dev-box",
+      "manual-exploration",
+      "skip",
+    ] as const;
+
+    for (const destination of destinations) {
+      expect(allocationDestinationSchema.parse(destination)).toBe(destination);
+    }
+  });
+
+  it("rejects unsupported destinations", () => {
+    expect(() => allocationDestinationSchema.parse("automation")).toThrow();
+  });
+});
+
+describe("allocationSourceSignalsSchema", () => {
+  it("parses structured source signals", () => {
+    const result = allocationSourceSignalsSchema.parse({
+      categories: ["permission", "ui"],
+      existingTestLayers: ["unit", "visual"],
+      gapAspects: ["permission", "happy-path"],
+      reviewComments: ["Please review auth guard"],
+      riskSignals: ["permission", "ui"],
+    });
+
+    expect(result.categories).toEqual(["permission", "ui"]);
+    expect(result.existingTestLayers).toEqual(["unit", "visual"]);
+    expect(result.gapAspects).toEqual(["permission", "happy-path"]);
+  });
+});
+
+describe("allocationItemSchema", () => {
+  it("parses a valid allocation item", () => {
+    const result = allocationItemSchema.parse({
+      riskAssessmentId: 1,
+      title: "Review permission guard in src/middleware/auth.ts",
+      changedFilePaths: ["src/middleware/auth.ts"],
+      riskLevel: "high",
+      recommendedDestination: "review",
+      confidence: 0.9,
+      rationale: "Permission changes should be reviewed before QA handoff",
+      sourceSignals: {
+        categories: ["permission"],
+        existingTestLayers: [],
+        gapAspects: ["permission"],
+        reviewComments: ["Needs auth guard review"],
+        riskSignals: ["permission"],
+      },
+    });
+
+    expect(result.riskAssessmentId).toBe(1);
+    expect(result.recommendedDestination).toBe("review");
+  });
+
+  it("rejects empty changedFilePaths", () => {
+    expect(() =>
+      allocationItemSchema.parse({
+        riskAssessmentId: 1,
+        title: "Broken",
+        changedFilePaths: [],
+        riskLevel: "low",
+        recommendedDestination: "skip",
+        confidence: 0.5,
+        rationale: "No files",
+        sourceSignals: {
+          categories: [],
+          existingTestLayers: [],
+          gapAspects: [],
+          reviewComments: [],
+          riskSignals: [],
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("createEmptyAllocationDestinationCounts", () => {
+  it("initializes all destinations to zero", () => {
+    expect(createEmptyAllocationDestinationCounts()).toEqual({
+      review: 0,
+      unit: 0,
+      integration: 0,
+      e2e: 0,
+      visual: 0,
+      "dev-box": 0,
+      "manual-exploration": 0,
+      skip: 0,
+    });
+  });
+});

--- a/tests/unit/allocation-repository.test.ts
+++ b/tests/unit/allocation-repository.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  countAllocationItemsByDestination,
+  listAllocationItems,
+  listAllocationItemsByDestination,
+  saveAllocationItems,
+  saveChangeAnalysis,
+  savePrIntake,
+  saveRiskAssessment,
+  saveTestMapping,
+} from "../../src/exploratory-testing/db/workspace-repository";
+import type { AllocationItem } from "../../src/exploratory-testing/models/allocation";
+import type { ChangeAnalysisResult } from "../../src/exploratory-testing/models/change-analysis";
+import type { PrMetadata } from "../../src/exploratory-testing/models/pr-intake";
+import type { RiskAssessmentResult } from "../../src/exploratory-testing/models/risk-assessment";
+import type { TestMappingResult } from "../../src/exploratory-testing/models/test-mapping";
+import { initializeWorkspace } from "../../src/exploratory-testing/tools/setup";
+import {
+  type TestWorkspace,
+  cleanupTestWorkspace,
+  createTestWorkspace,
+} from "../helpers/workspace";
+
+const workspaces: string[] = [];
+
+function createSamplePrMetadata(): PrMetadata {
+  return {
+    provider: "github",
+    repository: "owner/repo",
+    prNumber: 42,
+    title: "Add feature X",
+    description: "Implements feature X",
+    author: "alice",
+    baseBranch: "main",
+    headBranch: "feature/x",
+    headSha: "abc1234",
+    linkedIssues: [],
+    changedFiles: [
+      {
+        path: "src/index.ts",
+        status: "modified",
+        additions: 12,
+        deletions: 2,
+        previousPath: null,
+      },
+    ],
+    reviewComments: [],
+    fetchedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleChangeAnalysis(prIntakeId: number): ChangeAnalysisResult {
+  return {
+    prIntakeId,
+    fileAnalyses: [
+      {
+        path: "src/index.ts",
+        status: "modified",
+        additions: 12,
+        deletions: 2,
+        categories: [
+          { category: "validation", confidence: 0.9, reason: "Input parsing" },
+        ],
+      },
+    ],
+    relatedCodes: [],
+    viewpointSeeds: [],
+    summary: "1 file analyzed",
+    analyzedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleTestMapping(
+  prIntakeId: number,
+  changeAnalysisId: number,
+): TestMappingResult {
+  return {
+    prIntakeId,
+    changeAnalysisId,
+    testAssets: [],
+    testSummaries: [],
+    coverageGapMap: [],
+    missingLayers: [],
+    mappedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleRiskAssessment(
+  testMappingId: number,
+): RiskAssessmentResult {
+  return {
+    testMappingId,
+    riskScores: [
+      {
+        changedFilePath: "src/index.ts",
+        overallRisk: 0.78,
+        factors: [
+          { factor: "uncovered-aspects", weight: 0.4, contribution: 0.24 },
+          { factor: "change-magnitude", weight: 0.3, contribution: 0.15 },
+          { factor: "category-risk", weight: 0.3, contribution: 0.39 },
+        ],
+      },
+    ],
+    frameworkSelections: [],
+    explorationThemes: [],
+    assessedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createAllocationItems(riskAssessmentId: number): AllocationItem[] {
+  return [
+    {
+      riskAssessmentId,
+      title: "Review src/index.ts (permission)",
+      changedFilePaths: ["src/index.ts"],
+      riskLevel: "high",
+      recommendedDestination: "review",
+      confidence: 0.9,
+      rationale: "Permission changes should be reviewed before QA handoff.",
+      sourceSignals: {
+        categories: ["permission"],
+        existingTestLayers: [],
+        gapAspects: ["permission"],
+        reviewComments: ["Needs auth review"],
+        riskSignals: ["permission"],
+      },
+    },
+    {
+      riskAssessmentId,
+      title: "Unit coverage for src/index.ts (boundary)",
+      changedFilePaths: ["src/index.ts"],
+      riskLevel: "medium",
+      recommendedDestination: "unit",
+      confidence: 0.85,
+      rationale: "Boundary checks are deterministic and should be unit tested.",
+      sourceSignals: {
+        categories: ["validation"],
+        existingTestLayers: ["unit"],
+        gapAspects: ["boundary"],
+        reviewComments: [],
+        riskSignals: ["validation"],
+      },
+    },
+    {
+      riskAssessmentId,
+      title: "Manual exploration for src/index.ts (error-path)",
+      changedFilePaths: ["src/index.ts"],
+      riskLevel: "high",
+      recommendedDestination: "manual-exploration",
+      confidence: 0.4,
+      rationale: "This still needs hands-on validation.",
+      sourceSignals: {
+        categories: [],
+        existingTestLayers: [],
+        gapAspects: ["error-path"],
+        reviewComments: [],
+        riskSignals: ["timing"],
+      },
+    },
+  ];
+}
+
+describe("allocation repository", () => {
+  afterEach(async () => {
+    await Promise.all(workspaces.splice(0).map(cleanupTestWorkspace));
+  });
+
+  async function setupWorkspace(): Promise<
+    TestWorkspace & { databasePath: string }
+  > {
+    const workspace = await createTestWorkspace();
+    workspaces.push(workspace.root);
+    const result = await initializeWorkspace(
+      workspace.configPath,
+      workspace.manifestPath,
+    );
+    return { ...workspace, databasePath: result.databasePath };
+  }
+
+  function seedDependencies(databasePath: string): number {
+    const prIntake = savePrIntake(databasePath, createSamplePrMetadata());
+    const changeAnalysis = saveChangeAnalysis(
+      databasePath,
+      createSampleChangeAnalysis(prIntake.id),
+    );
+    const testMapping = saveTestMapping(
+      databasePath,
+      createSampleTestMapping(prIntake.id, changeAnalysis.id),
+    );
+    const riskAssessment = saveRiskAssessment(
+      databasePath,
+      createSampleRiskAssessment(testMapping.id),
+    );
+
+    return riskAssessment.id;
+  }
+
+  it("saves, lists, and counts allocation items", async () => {
+    const workspace = await setupWorkspace();
+    const riskAssessmentId = seedDependencies(workspace.databasePath);
+
+    const saved = saveAllocationItems(
+      workspace.databasePath,
+      riskAssessmentId,
+      createAllocationItems(riskAssessmentId),
+    );
+
+    expect(saved).toHaveLength(3);
+    expect(saved[0]?.recommendedDestination).toBe("review");
+
+    const listed = listAllocationItems(
+      workspace.databasePath,
+      riskAssessmentId,
+    );
+    expect(listed).toHaveLength(3);
+    expect(
+      listAllocationItemsByDestination(
+        workspace.databasePath,
+        riskAssessmentId,
+        "unit",
+      ),
+    ).toHaveLength(1);
+
+    expect(
+      countAllocationItemsByDestination(
+        workspace.databasePath,
+        riskAssessmentId,
+      ),
+    ).toEqual({
+      review: 1,
+      unit: 1,
+      integration: 0,
+      e2e: 0,
+      visual: 0,
+      "dev-box": 0,
+      "manual-exploration": 1,
+      skip: 0,
+    });
+  });
+
+  it("replaces prior allocation items for the same risk assessment", async () => {
+    const workspace = await setupWorkspace();
+    const riskAssessmentId = seedDependencies(workspace.databasePath);
+
+    saveAllocationItems(
+      workspace.databasePath,
+      riskAssessmentId,
+      createAllocationItems(riskAssessmentId),
+    );
+
+    const updated = saveAllocationItems(
+      workspace.databasePath,
+      riskAssessmentId,
+      [
+        {
+          riskAssessmentId,
+          title: "Review src/index.ts (permission)",
+          changedFilePaths: ["src/index.ts"],
+          riskLevel: "high",
+          recommendedDestination: "review",
+          confidence: 0.95,
+          rationale: "Updated review note",
+          sourceSignals: {
+            categories: ["permission"],
+            existingTestLayers: [],
+            gapAspects: ["permission"],
+            reviewComments: [],
+            riskSignals: ["permission"],
+          },
+        },
+      ],
+    );
+
+    expect(updated).toHaveLength(1);
+    expect(
+      listAllocationItems(workspace.databasePath, riskAssessmentId),
+    ).toHaveLength(1);
+  });
+
+  it("throws when the risk assessment parent is missing", async () => {
+    const workspace = await setupWorkspace();
+
+    expect(() => saveAllocationItems(workspace.databasePath, 999, [])).toThrow(
+      /Risk assessment not found/,
+    );
+  });
+});

--- a/tests/unit/github-issue-model.test.ts
+++ b/tests/unit/github-issue-model.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createdCommentSchema,
+  createdIssueSchema,
+} from "../../src/exploratory-testing/models/github-issue";
+
+describe("createdIssueSchema", () => {
+  it("parses valid gh issue create --json output", () => {
+    const json = {
+      number: 123,
+      url: "https://github.com/owner/repo/issues/123",
+      title: "QA: PR #42 — feature X",
+    };
+
+    const result = createdIssueSchema.parse(json);
+
+    expect(result.number).toBe(123);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/123");
+    expect(result.title).toBe("QA: PR #42 — feature X");
+  });
+
+  it("rejects missing number", () => {
+    const json = {
+      url: "https://github.com/owner/repo/issues/123",
+      title: "QA handoff",
+    };
+
+    expect(() => createdIssueSchema.parse(json)).toThrow();
+  });
+
+  it("rejects empty url", () => {
+    const json = {
+      number: 1,
+      url: "",
+      title: "QA handoff",
+    };
+
+    expect(() => createdIssueSchema.parse(json)).toThrow();
+  });
+
+  it("rejects empty title", () => {
+    const json = {
+      number: 1,
+      url: "https://github.com/owner/repo/issues/1",
+      title: "",
+    };
+
+    expect(() => createdIssueSchema.parse(json)).toThrow();
+  });
+
+  it("rejects non-positive number", () => {
+    const json = {
+      number: 0,
+      url: "https://github.com/owner/repo/issues/0",
+      title: "QA handoff",
+    };
+
+    expect(() => createdIssueSchema.parse(json)).toThrow();
+  });
+});
+
+describe("createdCommentSchema", () => {
+  it("parses valid gh issue comment --json output", () => {
+    const json = {
+      url: "https://github.com/owner/repo/issues/123#issuecomment-456",
+    };
+
+    const result = createdCommentSchema.parse(json);
+
+    expect(result.url).toBe(
+      "https://github.com/owner/repo/issues/123#issuecomment-456",
+    );
+  });
+
+  it("rejects empty url", () => {
+    const json = { url: "" };
+
+    expect(() => createdCommentSchema.parse(json)).toThrow();
+  });
+
+  it("rejects missing url", () => {
+    const json = {};
+
+    expect(() => createdCommentSchema.parse(json)).toThrow();
+  });
+});

--- a/tests/unit/github-issues.test.ts
+++ b/tests/unit/github-issues.test.ts
@@ -1,0 +1,264 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from "execa";
+
+import {
+  addIssueComment,
+  createIssue,
+  editIssueBody,
+} from "../../src/exploratory-testing/scm/github-issues";
+
+const execaMock = execa as unknown as Mock;
+
+describe("createIssue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh issue create with correct args and parses output", async () => {
+    execaMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 99,
+        url: "https://github.com/owner/repo/issues/99",
+        title: "QA: PR #42",
+      }),
+    });
+
+    const result = await createIssue({
+      repositoryRoot: "/workspace",
+      repository: "owner/repo",
+      title: "QA: PR #42",
+      body: "## Handoff\n\nTest body",
+    });
+
+    expect(execaMock).toHaveBeenCalledOnce();
+    const [command, args, options] = execaMock.mock.calls[0] as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(command).toBe("gh");
+    expect(args).toContain("issue");
+    expect(args).toContain("create");
+    expect(args).toContain("--repo");
+    expect(args).toContain("owner/repo");
+    expect(args).toContain("--title");
+    expect(args).toContain("QA: PR #42");
+    expect(args).toContain("--body");
+    expect(args).toContain("## Handoff\n\nTest body");
+    expect(args).toContain("--json");
+    expect(args).toContain("number,url,title");
+    expect(options.cwd).toBe("/workspace");
+
+    expect(result.number).toBe(99);
+    expect(result.url).toBe("https://github.com/owner/repo/issues/99");
+    expect(result.title).toBe("QA: PR #42");
+  });
+
+  it("includes labels when provided", async () => {
+    execaMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 100,
+        url: "https://github.com/owner/repo/issues/100",
+        title: "QA handoff",
+      }),
+    });
+
+    await createIssue({
+      repositoryRoot: "/workspace",
+      repository: "owner/repo",
+      title: "QA handoff",
+      body: "body",
+      labels: ["qa-handoff", "exploratory"],
+    });
+
+    const args = (execaMock.mock.calls[0] as [string, string[]])[1];
+    expect(args).toContain("--label");
+    expect(args).toContain("qa-handoff");
+    expect(args).toContain("exploratory");
+  });
+
+  it("includes assignees when provided", async () => {
+    execaMock.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 101,
+        url: "https://github.com/owner/repo/issues/101",
+        title: "QA handoff",
+      }),
+    });
+
+    await createIssue({
+      repositoryRoot: "/workspace",
+      repository: "owner/repo",
+      title: "QA handoff",
+      body: "body",
+      assignees: ["alice", "bob"],
+    });
+
+    const args = (execaMock.mock.calls[0] as [string, string[]])[1];
+    expect(args).toContain("--assignee");
+    expect(args).toContain("alice");
+    expect(args).toContain("bob");
+  });
+
+  it("throws on invalid gh output", async () => {
+    execaMock.mockResolvedValue({
+      stdout: JSON.stringify({ invalid: true }),
+    });
+
+    await expect(
+      createIssue({
+        repositoryRoot: "/workspace",
+        repository: "owner/repo",
+        title: "QA handoff",
+        body: "body",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws on gh command failure", async () => {
+    execaMock.mockRejectedValue(
+      Object.assign(new Error("Command failed"), {
+        exitCode: 1,
+        stderr: "Not Found",
+      }),
+    );
+
+    await expect(
+      createIssue({
+        repositoryRoot: "/workspace",
+        repository: "owner/repo",
+        title: "QA handoff",
+        body: "body",
+      }),
+    ).rejects.toThrow(/gh.*issue.*create/);
+  });
+});
+
+describe("editIssueBody", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh issue edit with correct args", async () => {
+    execaMock.mockResolvedValue({ stdout: "" });
+
+    await editIssueBody({
+      repositoryRoot: "/workspace",
+      repository: "owner/repo",
+      issueNumber: 99,
+      body: "Updated body",
+    });
+
+    expect(execaMock).toHaveBeenCalledOnce();
+    const [command, args, options] = execaMock.mock.calls[0] as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(command).toBe("gh");
+    expect(args).toContain("issue");
+    expect(args).toContain("edit");
+    expect(args).toContain("99");
+    expect(args).toContain("--repo");
+    expect(args).toContain("owner/repo");
+    expect(args).toContain("--body");
+    expect(args).toContain("Updated body");
+    expect(options.cwd).toBe("/workspace");
+  });
+
+  it("throws on gh command failure", async () => {
+    execaMock.mockRejectedValue(
+      Object.assign(new Error("Command failed"), {
+        exitCode: 1,
+        stderr: "Not Found",
+      }),
+    );
+
+    await expect(
+      editIssueBody({
+        repositoryRoot: "/workspace",
+        repository: "owner/repo",
+        issueNumber: 99,
+        body: "body",
+      }),
+    ).rejects.toThrow(/gh.*issue.*edit/);
+  });
+});
+
+describe("addIssueComment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls gh issue comment with correct args and parses plain-text URL output", async () => {
+    // gh issue comment outputs a plain-text URL, not JSON
+    execaMock.mockResolvedValue({
+      stdout: "https://github.com/owner/repo/issues/99#issuecomment-789\n",
+    });
+
+    const result = await addIssueComment({
+      repositoryRoot: "/workspace",
+      repository: "owner/repo",
+      issueNumber: 99,
+      body: "Findings comment",
+    });
+
+    expect(execaMock).toHaveBeenCalledOnce();
+    const [command, args, options] = execaMock.mock.calls[0] as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(command).toBe("gh");
+    expect(args).toContain("issue");
+    expect(args).toContain("comment");
+    expect(args).toContain("99");
+    expect(args).toContain("--repo");
+    expect(args).toContain("owner/repo");
+    expect(args).toContain("--body");
+    expect(args).toContain("Findings comment");
+    expect(options.cwd).toBe("/workspace");
+
+    expect(result.url).toBe(
+      "https://github.com/owner/repo/issues/99#issuecomment-789",
+    );
+  });
+
+  it("throws on empty gh output", async () => {
+    execaMock.mockResolvedValue({
+      stdout: "",
+    });
+
+    await expect(
+      addIssueComment({
+        repositoryRoot: "/workspace",
+        repository: "owner/repo",
+        issueNumber: 99,
+        body: "body",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws on gh command failure", async () => {
+    execaMock.mockRejectedValue(
+      Object.assign(new Error("Command failed"), {
+        exitCode: 1,
+        stderr: "auth required",
+      }),
+    );
+
+    await expect(
+      addIssueComment({
+        repositoryRoot: "/workspace",
+        repository: "owner/repo",
+        issueNumber: 99,
+        body: "body",
+      }),
+    ).rejects.toThrow(/gh.*issue.*comment/);
+  });
+});

--- a/tests/unit/handoff-tool.test.ts
+++ b/tests/unit/handoff-tool.test.ts
@@ -1,0 +1,483 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/exploratory-testing/scm/github-issues", () => ({
+  createIssue: vi.fn(),
+  editIssueBody: vi.fn(),
+  addIssueComment: vi.fn(),
+}));
+
+import {
+  countAllocationItemsByDestination,
+  saveAllocationItems,
+  saveChangeAnalysis,
+  saveFinding,
+  saveObservation,
+  savePrIntake,
+  saveRiskAssessment,
+  saveSession,
+  saveSessionCharters,
+  saveTestMapping,
+  updateSessionStatus,
+} from "../../src/exploratory-testing/db/workspace-repository";
+import type { AllocationItem } from "../../src/exploratory-testing/models/allocation";
+import type { ChangeAnalysisResult } from "../../src/exploratory-testing/models/change-analysis";
+import type { PrMetadata } from "../../src/exploratory-testing/models/pr-intake";
+import type { RiskAssessmentResult } from "../../src/exploratory-testing/models/risk-assessment";
+import type { SessionCharterGenerationResult } from "../../src/exploratory-testing/models/session-charter";
+import type { TestMappingResult } from "../../src/exploratory-testing/models/test-mapping";
+import {
+  addIssueComment,
+  createIssue,
+  editIssueBody,
+} from "../../src/exploratory-testing/scm/github-issues";
+import {
+  generateHandoffMarkdown,
+  groupBySection,
+  renderFindingsComment,
+  runAddHandoffComment,
+  runCreateHandoffIssue,
+  runUpdateHandoffIssue,
+} from "../../src/exploratory-testing/tools/handoff";
+import { initializeWorkspace } from "../../src/exploratory-testing/tools/setup";
+import type { generateTriageReport } from "../../src/exploratory-testing/tools/triage-findings";
+import {
+  type TestWorkspace,
+  cleanupTestWorkspace,
+  createTestWorkspace,
+} from "../helpers/workspace";
+
+const workspaces: string[] = [];
+
+function createSamplePrMetadata(): PrMetadata {
+  return {
+    provider: "github",
+    repository: "owner/repo",
+    prNumber: 42,
+    title: "Payment retry | handoff",
+    description: "Implements retry behavior",
+    author: "alice",
+    baseBranch: "main",
+    headBranch: "feature/payment-retry",
+    headSha: "abc1234",
+    linkedIssues: [],
+    changedFiles: [
+      {
+        path: "src/clients/payment-gateway.ts",
+        status: "modified",
+        additions: 20,
+        deletions: 4,
+        previousPath: null,
+      },
+    ],
+    reviewComments: [],
+    fetchedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleChangeAnalysis(prIntakeId: number): ChangeAnalysisResult {
+  return {
+    prIntakeId,
+    fileAnalyses: [
+      {
+        path: "src/clients/payment-gateway.ts",
+        status: "modified",
+        additions: 20,
+        deletions: 4,
+        categories: [
+          { category: "api", confidence: 0.8, reason: "Gateway client" },
+          { category: "async", confidence: 0.8, reason: "Retry timing" },
+        ],
+      },
+    ],
+    relatedCodes: [],
+    viewpointSeeds: [],
+    summary: "1 file analyzed",
+    analyzedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleTestMapping(
+  prIntakeId: number,
+  changeAnalysisId: number,
+): TestMappingResult {
+  return {
+    prIntakeId,
+    changeAnalysisId,
+    testAssets: [],
+    testSummaries: [],
+    coverageGapMap: [
+      {
+        changedFilePath: "src/clients/payment-gateway.ts",
+        aspect: "error-path",
+        status: "uncovered",
+        coveredBy: [],
+        explorationPriority: "high",
+      },
+    ],
+    missingLayers: ["e2e", "visual"],
+    mappedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createSampleRiskAssessment(
+  testMappingId: number,
+): RiskAssessmentResult {
+  return {
+    testMappingId,
+    riskScores: [
+      {
+        changedFilePath: "src/clients/payment-gateway.ts",
+        overallRisk: 0.9,
+        factors: [{ factor: "cross-service", weight: 0.5, contribution: 0.45 }],
+      },
+    ],
+    frameworkSelections: [],
+    explorationThemes: [],
+    assessedAt: "2026-04-01T00:00:00Z",
+  };
+}
+
+function createAllocationItems(riskAssessmentId: number): AllocationItem[] {
+  return [
+    {
+      riskAssessmentId,
+      title: "Covered auth guard",
+      changedFilePaths: ["src/api/orders.ts"],
+      riskLevel: "low",
+      recommendedDestination: "review",
+      confidence: 0.9,
+      rationale: "Reviewed in code review",
+      sourceSignals: {
+        categories: ["permission"],
+        existingTestLayers: [],
+        gapAspects: ["permission"],
+        reviewComments: [],
+        riskSignals: ["review"],
+      },
+    },
+    {
+      riskAssessmentId,
+      title: "Retry boundary | automation",
+      changedFilePaths: ["src/clients/payment-gateway.ts"],
+      riskLevel: "high",
+      recommendedDestination: "integration",
+      confidence: 0.86,
+      rationale: "Boundary + retry should be integration tested",
+      sourceSignals: {
+        categories: ["api", "async"],
+        existingTestLayers: [],
+        gapAspects: ["boundary"],
+        reviewComments: [],
+        riskSignals: ["integration"],
+      },
+    },
+    {
+      riskAssessmentId,
+      title: "Retry timeout newline\nneeds hands-on",
+      changedFilePaths: ["src/clients/payment-gateway.ts"],
+      riskLevel: "high",
+      recommendedDestination: "manual-exploration",
+      confidence: 0.35,
+      rationale: "Timeout | stale state\nneeds observation",
+      sourceSignals: {
+        categories: ["async"],
+        existingTestLayers: [],
+        gapAspects: ["error-path"],
+        reviewComments: [],
+        riskSignals: ["manual"],
+      },
+    },
+  ];
+}
+
+describe("handoff tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(workspaces.splice(0).map(cleanupTestWorkspace));
+  });
+
+  async function setupWorkspace(): Promise<
+    TestWorkspace & { databasePath: string }
+  > {
+    const workspace = await createTestWorkspace();
+    workspaces.push(workspace.root);
+    const result = await initializeWorkspace(
+      workspace.configPath,
+      workspace.manifestPath,
+    );
+    return { ...workspace, databasePath: result.databasePath };
+  }
+
+  function seedHandoffPipeline(databasePath: string): {
+    riskAssessmentId: number;
+    sessionId: number;
+  } {
+    const prIntake = savePrIntake(databasePath, createSamplePrMetadata());
+    const changeAnalysis = saveChangeAnalysis(
+      databasePath,
+      createSampleChangeAnalysis(prIntake.id),
+    );
+    const testMapping = saveTestMapping(
+      databasePath,
+      createSampleTestMapping(prIntake.id, changeAnalysis.id),
+    );
+    const riskAssessment = saveRiskAssessment(
+      databasePath,
+      createSampleRiskAssessment(testMapping.id),
+    );
+    saveAllocationItems(
+      databasePath,
+      riskAssessment.id,
+      createAllocationItems(riskAssessment.id),
+    );
+
+    const sessionCharters = saveSessionCharters(databasePath, {
+      riskAssessmentId: riskAssessment.id,
+      charters: [
+        {
+          title: "Retry resilience",
+          goal: "Observe timeout behavior",
+          scope: ["src/clients/payment-gateway.ts"],
+          selectedFrameworks: ["error-guessing"],
+          preconditions: [],
+          observationTargets: [
+            {
+              category: "network",
+              description: "Observe timeout and retry requests",
+            },
+          ],
+          stopConditions: ["Timebox elapsed"],
+          timeboxMinutes: 20,
+        },
+      ],
+      generatedAt: "2026-04-01T00:00:00Z",
+    } satisfies SessionCharterGenerationResult);
+
+    const session = saveSession(databasePath, {
+      sessionChartersId: sessionCharters.id,
+      charterIndex: 0,
+      charterTitle: "Retry resilience",
+    });
+    updateSessionStatus(databasePath, {
+      sessionId: session.id,
+      status: "completed",
+      startedAt: "2026-04-01T10:00:00Z",
+      completedAt: "2026-04-01T10:20:00Z",
+    });
+
+    const observationOne = saveObservation(databasePath, {
+      sessionId: session.id,
+      targetedHeuristic: "error-guessing",
+      action: "Trigger gateway timeout",
+      expected: "Single retry request",
+      actual: "Duplicate retry request",
+      outcome: "fail",
+      note: "",
+      evidencePath: null,
+    });
+
+    const observationTwo = saveObservation(databasePath, {
+      sessionId: session.id,
+      targetedHeuristic: "boundary-value-analysis",
+      action: "Retry after timeout",
+      expected: "Stable contract behavior",
+      actual: "Needs automated coverage",
+      outcome: "suspicious",
+      note: "",
+      evidencePath: null,
+    });
+
+    saveFinding(databasePath, {
+      sessionId: session.id,
+      observationId: observationOne.id,
+      type: "defect",
+      title: "Duplicate retry request",
+      description: "Observed duplicate request after timeout",
+      severity: "high",
+      recommendedTestLayer: null,
+      automationRationale: null,
+    });
+
+    saveFinding(databasePath, {
+      sessionId: session.id,
+      observationId: observationTwo.id,
+      type: "automation-candidate",
+      title: "Retry backoff contract",
+      description: "Should be pinned with integration coverage",
+      severity: "medium",
+      recommendedTestLayer: "integration",
+      automationRationale: "Gateway timeout path is deterministic enough",
+    });
+
+    return {
+      riskAssessmentId: riskAssessment.id,
+      sessionId: session.id,
+    };
+  }
+
+  it("groups allocation items into the expected handoff sections", async () => {
+    const workspace = await setupWorkspace();
+    const { riskAssessmentId } = seedHandoffPipeline(workspace.databasePath);
+    const items = saveAllocationItems(
+      workspace.databasePath,
+      riskAssessmentId,
+      createAllocationItems(riskAssessmentId),
+    );
+
+    const sections = groupBySection(items);
+
+    expect(sections.alreadyCovered).toHaveLength(1);
+    expect(sections.shouldAutomate).toHaveLength(1);
+    expect(sections.manualExploration).toHaveLength(1);
+  });
+
+  it("generates markdown from allocation items with escaped markdown-sensitive content", async () => {
+    const workspace = await setupWorkspace();
+    const { riskAssessmentId } = seedHandoffPipeline(workspace.databasePath);
+
+    const result = await generateHandoffMarkdown({
+      riskAssessmentId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    expect(result.summary.totalItems).toBe(3);
+    expect(result.markdown).toContain("### ✅ Already Covered");
+    expect(result.markdown).toContain("### 🔧 Should Automate");
+    expect(result.markdown).toContain("### 🔍 Manual Exploration Required");
+    expect(result.markdown).toContain(
+      "Timeout \\| stale state<br>needs observation",
+    );
+  });
+
+  it("publishes a generated handoff issue via the gh wrapper", async () => {
+    const workspace = await setupWorkspace();
+    const { riskAssessmentId } = seedHandoffPipeline(workspace.databasePath);
+    vi.mocked(createIssue).mockResolvedValue({
+      number: 42,
+      url: "https://github.com/owner/repo/issues/42",
+      title: "QA: PR #42 — handoff checklist",
+    });
+
+    const result = await runCreateHandoffIssue({
+      riskAssessmentId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+      labels: ["qa-handoff"],
+    });
+
+    expect(vi.mocked(createIssue)).toHaveBeenCalledOnce();
+    expect(vi.mocked(createIssue)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryRoot: workspace.root,
+        repository: "owner/repo",
+        labels: ["qa-handoff"],
+        body: expect.stringContaining("Manual Exploration Required"),
+      }),
+    );
+    expect(result.issue.number).toBe(42);
+  });
+
+  it("updates an existing issue body from allocation data", async () => {
+    const workspace = await setupWorkspace();
+    const { riskAssessmentId } = seedHandoffPipeline(workspace.databasePath);
+    vi.mocked(editIssueBody).mockResolvedValue(undefined);
+
+    const result = await runUpdateHandoffIssue({
+      riskAssessmentId,
+      issueNumber: 77,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    expect(vi.mocked(editIssueBody)).toHaveBeenCalledOnce();
+    expect(vi.mocked(editIssueBody)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueNumber: 77,
+        repositoryRoot: workspace.root,
+        body: expect.stringContaining("Should Automate"),
+      }),
+    );
+    expect(result.issueNumber).toBe(77);
+  });
+
+  it("renders findings and posts them as a comment", async () => {
+    const workspace = await setupWorkspace();
+    const { sessionId } = seedHandoffPipeline(workspace.databasePath);
+    vi.mocked(addIssueComment).mockResolvedValue({
+      url: "https://github.com/owner/repo/issues/42#issuecomment-1",
+    });
+
+    const result = await runAddHandoffComment({
+      issueNumber: 42,
+      sessionId,
+      configPath: workspace.configPath,
+      manifestPath: workspace.manifestPath,
+    });
+
+    expect(vi.mocked(addIssueComment)).toHaveBeenCalledOnce();
+    expect(result.body).toContain("Duplicate retry request");
+    expect(result.body).toContain("Recommended layer");
+    expect(result.comment.url).toContain("issuecomment-1");
+  });
+
+  it("renders a no-findings comment when the triage report is empty", async () => {
+    const session = {
+      id: 1,
+      sessionChartersId: 1,
+      charterIndex: 0,
+      charterTitle: "Retry resilience",
+      status: "completed",
+      startedAt: null,
+      interruptedAt: null,
+      completedAt: null,
+      interruptReason: null,
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+    } as const;
+    const report = {
+      sessionId: 1,
+      totalFindings: 0,
+      countByType: {
+        defect: 0,
+        "spec-gap": 0,
+        "automation-candidate": 0,
+      },
+      countBySeverity: {
+        low: 0,
+        medium: 0,
+        high: 0,
+        critical: 0,
+      },
+      findings: [],
+    } satisfies Awaited<ReturnType<typeof generateTriageReport>>;
+
+    expect(renderFindingsComment(session, report)).toContain(
+      "_No findings from this session._",
+    );
+  });
+
+  it("builds destination counts consistent with the saved allocation data", async () => {
+    const workspace = await setupWorkspace();
+    const { riskAssessmentId } = seedHandoffPipeline(workspace.databasePath);
+
+    expect(
+      countAllocationItemsByDestination(
+        workspace.databasePath,
+        riskAssessmentId,
+      ),
+    ).toEqual({
+      review: 1,
+      unit: 0,
+      integration: 1,
+      e2e: 0,
+      visual: 0,
+      "dev-box": 0,
+      "manual-exploration": 1,
+      skip: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add allocation models, persistence, repository queries, and CLI commands (`allocate run|list|summary`)
- add GitHub issue wrappers and handoff generation/publish/update/comment flows for QA handoff via `gh issue create/edit/comment`
- add unit coverage for allocation and handoff workflows, including markdown rendering and findings comment generation

## Verification

- `bun run check`

## Related

- Parent: #33
- Slice: #40
- Slice: #37
- Slice: #42
