### PR TITLE
feat: add heuristic feedback report to export-artifacts

### DIFF
--- a/src/exploratory-testing/tools/export-artifacts.ts
+++ b/src/exploratory-testing/tools/export-artifacts.ts
@@ -543,6 +543,9 @@ function buildHeuristicFeedbackReport(data: CollectedData): string {
   );
   lines.push(...buildFindingsByGapAspect(findingAllocations));
   lines.push(...buildFindingsByCharter(findings, sessionById, sessionCharters));
+  lines.push(
+    ...buildFindingsByFramework(findings, sessionById, sessionCharters),
+  );
 
   return lines.join("\n");
 }
@@ -569,13 +572,19 @@ function resolveFindingAllocations(
       return { finding, matchedItems: [] };
     }
 
-    // Collect allocation items whose changedFilePaths overlap with charter scope
+    // Collect only manual-exploration allocation items whose changedFilePaths
+    // overlap with charter scope. Charters are generated from manual-exploration
+    // items, so findings should only be attributed to those — not to items that
+    // were shifted left (unit, review, etc.) and never explored.
     const matchedItemIds = new Set<number>();
     const matchedItems: PersistedAllocationItem[] = [];
     for (const scopePath of charter.scope) {
       const items = allocationsByFile.get(scopePath) ?? [];
       for (const item of items) {
-        if (!matchedItemIds.has(item.id)) {
+        if (
+          item.recommendedDestination === "manual-exploration" &&
+          !matchedItemIds.has(item.id)
+        ) {
           matchedItemIds.add(item.id);
           matchedItems.push(item);
         }
@@ -737,6 +746,48 @@ function buildFindingsByCharter(
     lines.push(
       `| ${escapePipe(charter.title)} | ${escapePipe(frameworks)} | ${count} |`,
     );
+  }
+  lines.push("");
+
+  return lines;
+}
+
+function buildFindingsByFramework(
+  findings: readonly PersistedFinding[],
+  sessionById: ReadonlyMap<number, PersistedSession>,
+  sessionCharters: PersistedSessionCharters,
+): readonly string[] {
+  const lines: string[] = [];
+  lines.push("## Findings by Framework", "");
+
+  // Count findings per framework across all charters
+  const findingCountByFramework = new Map<string, number>();
+  for (const finding of findings) {
+    const session = sessionById.get(finding.sessionId);
+    if (!session) continue;
+
+    const charter = sessionCharters.charters[session.charterIndex];
+    if (!charter) continue;
+
+    const frameworks = new Set(charter.selectedFrameworks);
+    for (const framework of frameworks) {
+      const count = findingCountByFramework.get(framework) ?? 0;
+      findingCountByFramework.set(framework, count + 1);
+    }
+  }
+
+  if (findingCountByFramework.size === 0) {
+    lines.push("No frameworks linked to findings.", "");
+    return lines;
+  }
+
+  lines.push("| Framework | Findings |");
+  lines.push("| --- | --- |");
+  const sorted = [...findingCountByFramework.entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  );
+  for (const [framework, count] of sorted) {
+    lines.push(`| ${escapePipe(framework)} | ${count} |`);
   }
   lines.push("");
 

--- a/tests/helpers/seed-data.ts
+++ b/tests/helpers/seed-data.ts
@@ -88,7 +88,7 @@ export function seedSessionCharters(databasePath: string): {
         title: "Auth error handling",
         goal: "Verify error responses",
         scope: ["src/middleware/auth.ts"],
-        selectedFrameworks: ["error-guessing"],
+        selectedFrameworks: ["error-guessing", "boundary-value-analysis"],
         preconditions: [],
         observationTargets: [
           { category: "network", description: "Check responses" },

--- a/tests/unit/export-artifacts-tool.test.ts
+++ b/tests/unit/export-artifacts-tool.test.ts
@@ -656,7 +656,7 @@ describe("export-artifacts tool", () => {
       );
     });
 
-    it("contains findings-by-destination section", async () => {
+    it("attributes findings only to manual-exploration destination", async () => {
       const workspace = await setupWithAllocations();
       const config = await readPluginConfig(
         workspace.configPath,
@@ -671,10 +671,15 @@ describe("export-artifacts tool", () => {
 
       expect(content).toContain("# Heuristic Feedback Report");
       expect(content).toContain("## Findings by Allocation Destination");
-      expect(content).toContain("manual-exploration");
+      // manual-exploration has 1 item and 2 findings
+      expect(content).toContain("| manual-exploration | 1 | 2 |");
+      // review has 1 item but 0 findings (not explored)
+      expect(content).toContain("| review | 1 | 0 |");
+      // unit has 1 item but 0 findings (not explored)
+      expect(content).toContain("| unit | 1 | 0 |");
     });
 
-    it("contains findings-by-confidence-bucket section", async () => {
+    it("attributes confidence bucket only from manual-exploration items", async () => {
       const workspace = await setupWithAllocations();
       const config = await readPluginConfig(
         workspace.configPath,
@@ -688,10 +693,15 @@ describe("export-artifacts tool", () => {
       );
 
       expect(content).toContain("## Findings by Confidence Bucket");
-      expect(content).toContain("high");
+      // manual-exploration item has confidence 0.85 = high bucket, 2 findings
+      expect(content).toContain("| high | 1 | 2 |");
+      // medium bucket has 1 item (unit, confidence 0.7) but 0 findings
+      expect(content).toContain("| medium | 1 | 0 |");
+      // low bucket has 1 item (review, confidence 0.4) but 0 findings
+      expect(content).toContain("| low | 1 | 0 |");
     });
 
-    it("contains findings-by-gap-aspect section", async () => {
+    it("attributes gap aspects only from manual-exploration items", async () => {
       const workspace = await setupWithAllocations();
       const config = await readPluginConfig(
         workspace.configPath,
@@ -705,7 +715,13 @@ describe("export-artifacts tool", () => {
       );
 
       expect(content).toContain("## Findings by Gap Aspect");
-      expect(content).toContain("error-path");
+      // manual-exploration item has gapAspects: ["error-path", "permission"]
+      expect(content).toContain("| error-path | 2 |");
+      expect(content).toContain("| permission | 2 |");
+      // "boundary" is only on the unit item — should NOT appear
+      expect(content).not.toContain("| boundary |");
+      // "happy-path" is only on the review item — should NOT appear
+      expect(content).not.toContain("| happy-path |");
     });
 
     it("contains findings-by-charter section", async () => {
@@ -723,7 +739,25 @@ describe("export-artifacts tool", () => {
 
       expect(content).toContain("## Findings by Charter");
       expect(content).toContain("Auth error handling");
-      expect(content).toContain("error-guessing");
+    });
+
+    it("contains findings-by-framework section", async () => {
+      const workspace = await setupWithAllocations();
+      const config = await readPluginConfig(
+        workspace.configPath,
+        workspace.manifestPath,
+      );
+
+      const result = await exportArtifacts({ prIntakeId: 1, config });
+      const content = await readFile(
+        result.artifacts.heuristicFeedbackReport,
+        "utf8",
+      );
+
+      expect(content).toContain("## Findings by Framework");
+      // charter has selectedFrameworks: ["error-guessing", "boundary-value-analysis"]
+      expect(content).toContain("| boundary-value-analysis | 2 |");
+      expect(content).toContain("| error-guessing | 2 |");
     });
 
     it("shows empty findings when no findings exist", async () => {


### PR DESCRIPTION
## Summary

Closes #52

- `export-artifacts` に6番目のアーティファクト `heuristic-feedback-report.md` を追加
- findings を allocation destination / confidence bucket / coverage gap aspect / charter・framework に引き戻して集計する feedback report を生成
- findings 0件の場合は空レポートとして扱い、対象不存在（PR intake 未登録等）とは区別
- `CollectedData` に `allocationItems` を追加し、`collectData` で取得
- `seedSessionChartersWithAllocations` テストヘルパーを追加
- 7件のテストを追加（artifact 出力、各セクション内容、空 findings、handover 記載）

## Changes

| File | Change |
|------|--------|
| `src/exploratory-testing/tools/export-artifacts.ts` | feedback report 生成ロジック追加、CollectedData 拡張 |
| `tests/helpers/seed-data.ts` | allocation items 付き seed ヘルパー追加 |
| `tests/unit/export-artifacts-tool.test.ts` | feedback report テスト7件追加、既存テスト名を6 artifacts に更新 |

## Test plan

- [x] `bun run test` — 559/559 passed
- [x] `bun run typecheck` — clean
- [x] E2E full pipeline test passes (T7: exported artifacts)
- [x] code-simplifier review — 共通ヘルパー抽出済み
- [x] code-reviewer review — escapePipe / テスト名 / 未使用変数 指摘対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)