### PR TITLE
docs: align publish-handoff README with public flow

### DIFF
--- a/skills/publish-handoff/README.md
+++ b/skills/publish-handoff/README.md
@@ -1,11 +1,14 @@
 # publish-handoff
 
-QA handoff Issue の publish / update と、必要なら findings comment 返却まで扱う
-public skill です。
+QA handoff Issue の publish / update を扱う public skill です。
 
 主な役割:
 
 - GitHub Issue create / update を行う
-- 必要なら findings comment を追加する
 - publish 前に title / target issue / scope を確認する
 - 完了後に issue URL や publish 結果を返す
+
+補足:
+
+- findings comment の追加は別の低レベル CLI コマンドで行う
+- 標準の public flow は handoff Issue の publish / update までを責務とする


### PR DESCRIPTION
## Summary
- remove the unsupported findings-comment promise from `skills/publish-handoff/README.md`
- clarify that the standard public flow only covers handoff issue publish/update
- note that comment posting is handled by a separate low-level CLI command

## Testing
- not run (docs-only change)